### PR TITLE
Improve Background Color Consistency

### DIFF
--- a/resources/wren/shaders/gtao_combine.frag
+++ b/resources/wren/shaders/gtao_combine.frag
@@ -26,7 +26,9 @@ void main() {
   vec2 aoOut = textureLod(inputTextures[1], texUv, 0).rg;
   float ao = aoOut.r;
 
-  if (ao >= 1.0)
+  fragDepth = textureLod(inputTextures[2], texUv, 0).x;
+
+  if (ao >= 1.0 || fragDepth == 1.0)
     fragColor = base;
   else {
     fragColor.rgb = base.rgb * MultiBounce(ao, base.rgb);
@@ -34,5 +36,4 @@ void main() {
     fragColor.a = 1.0;
   }
   fragAo = vec4(aoOut.rg, 0.0, 0.0);
-  fragDepth = textureLod(inputTextures[2], texUv, 0).r;
 }

--- a/src/webots/nodes/WbBackground.cpp
+++ b/src/webots/nodes/WbBackground.cpp
@@ -24,6 +24,7 @@
 #include "WbNodeOperations.hpp"
 #include "WbSFNode.hpp"
 #include "WbUrl.hpp"
+#include "WbViewpoint.hpp"
 #include "WbWorld.hpp"
 #include "WbWrenRenderingContext.hpp"
 #include "WbWrenShaders.hpp"
@@ -277,11 +278,15 @@ void WbBackground::applyColourToWren(const WbRgb &color) {
   if (areWrenObjectsInitialized()) {
     // use wren's set_diffuse to transform to linear color space
     wr_phong_material_set_diffuse(mHdrClearMaterial, value);
-    float *linearDiffuse = new float[4];
-    wr_phong_material_get_linear_diffuse(mHdrClearMaterial, linearDiffuse);
 
-    // exposure adjustment for better color reproduction at default exposure
-    const float hdrColor[] = {linearDiffuse[0] * 2.0f, linearDiffuse[1] * 2.0f, linearDiffuse[2] * 2.0f};
+    // de-gamma correct
+    float hdrColor[] = {powf(value[0], 2.2), powf(value[1], 2.2), powf(value[2], 2.2)};
+
+    // reverse tone map
+    const float exposure = WbWorld::instance()->viewpoint()->exposure()->value();
+    for (int i = 0; i < 3; ++i) {
+      hdrColor[i] = -log(1.000000001 - hdrColor[i]) / exposure;
+    }
 
     wr_phong_material_set_linear_diffuse(mHdrClearMaterial, hdrColor);
     wr_scene_set_hdr_clear_quad(wr_scene_get_instance(), mHdrClearRenderable);

--- a/src/webots/nodes/WbViewpoint.hpp
+++ b/src/webots/nodes/WbViewpoint.hpp
@@ -77,6 +77,7 @@ public:
   WbSFDouble *fieldOfView() const { return mFieldOfView; }
   int projectionMode() const { return mProjectionMode; }
   float viewDistanceUnscaling(WbVector3 position) const;
+  WbSFDouble *exposure() const { return mExposure; }
 
   // setters
   void decOrthographicViewHeight();


### PR DESCRIPTION
As reported in https://www.cyberbotics.com/forum?message=8739, due to the HDR rendering system the actual color vs the background color selected show some discrepancies.

This PR attempts to apply the inverse of the HDR formula to get as close a matching as possible between the selected and rendered colors (now the correspondance is exact).