### PR TITLE
Advanced Post-Processing on Cameras

### DIFF
--- a/change_logs/ChangeLog.html
+++ b/change_logs/ChangeLog.html
@@ -9,6 +9,28 @@
 
 <h1>Webots change log</h1>
 
+<h2><a href='https://cyberbotics.com/doc/blog/Webots-2018-b-release'>Webots R2018b</a></h2>
+Released on July 5th, 2018
+
+<ul>
+<li><b>New Features</b></li>
+<ul>
+<li>Bloom and Ambient Occlusion are now also available as effects for color cameras.</li>
+</ul>
+<li><b>Upgrade</b></li>
+<ul>
+</ul>
+<li><b>Enhancements</b></li>
+<ul>
+</ul>
+<li><b>Bug fix</b></li>
+<ul>
+</ul>
+<li><b>Cleanup</b></li>
+<ul>
+</ul>
+</ul>
+
 <h2><a href='https://cyberbotics.com/doc/blog/Webots-2019-a-release'>Webots R2019a</a></h2>
 Released on December 17th, 2018
 

--- a/change_logs/ChangeLog.html
+++ b/change_logs/ChangeLog.html
@@ -9,8 +9,8 @@
 
 <h1>Webots change log</h1>
 
-<h2><a href='https://cyberbotics.com/doc/blog/Webots-2018-b-release'>Webots R2018b</a></h2>
-Released on July 5th, 2018
+<h2><a href='https://cyberbotics.com/doc/blog/Webots-2018-b-release'>Webots R2019b</a></h2>
+Released on xx xxth, 2019
 
 <ul>
 <li><b>New Features</b></li>

--- a/docs/reference/camera.md
+++ b/docs/reference/camera.md
@@ -61,12 +61,13 @@ Anti-aliasing is a technique that selectively blurs these jagged edges (and thus
 - The `ambientOcclusionRadius` field denotes the radius of geometric occlusion searches in the scene.
 Increasing the radius can increase occlusion from further objects.
 However, at lower quality levels, near-field occlusion can start to disappear as the radius increases.
-This effect is disabled by default on cameras for performance reasons.
+This effect is disabled by default on cameras for performance reasons, with a value of `0`.
+Setting this field to any positive non-zero value enables the effect.
 
 - The `bloomThreshold` field denotes the luminosity above which pixels start to "bloom" - i.e. overexpose the camera and leak light around themselves.
 Decreasing the threshold means pixels bloom more easily, as if the camera were more easily overexposed.
 The effect is disabled by default, with a default threshold of `-1`.
-Setting this value to 0 or any positive value re-enables the effect.
+Setting this value to 0 or any positive value enables the effect.
 Please note this effect is not physically based, like with Ambient Occlusion (GTAO) or PBR.
 It serves as a good approximation of camera overexposure, however.
 

--- a/docs/reference/camera.md
+++ b/docs/reference/camera.md
@@ -4,21 +4,23 @@ Derived from [Device](device.md) and [Solid](solid.md).
 
 ```
 Camera {
-  SFFloat  fieldOfView  0.7854  # [0, pi]
-  SFInt32  width        64      # [0, inf)
-  SFInt32  height       64      # [0, inf)
-  SFBool   spherical    FALSE   # {TRUE, FALSE}
-  SFFloat  near         0.01    # [0, inf)
-  SFFloat  far          0.0     # [0, inf)
-  SFBool   antiAliasing FALSE   # {TRUE, FALSE}
-  SFFloat  motionBlur   0.0     # [0, inf)
-  SFFloat  noise        0.0     # [0, 1]
-  SFString noiseMaskUrl ""      # any string
-  SFNode   lens         NULL    # {Lens, PROTO}
-  SFNode   focus        NULL    # {Focus, PROTO}
-  SFNode   zoom         NULL    # {Zoom, PROTO}
-  SFNode   recognition  NULL    # {Recognition, PROTO}
-  SFNode   lensFlare    NULL    # {LensFlare, PROTO}
+  SFFloat  fieldOfView            0.7854  # [0, pi]
+  SFInt32  width                  64      # [0, inf)
+  SFInt32  height                 64      # [0, inf)
+  SFBool   spherical              FALSE   # {TRUE, FALSE}
+  SFFloat  near                   0.01    # [0, inf)
+  SFFloat  far                    0.0     # [0, inf)
+  SFBool   antiAliasing           FALSE   # {TRUE, FALSE}
+  SFFloat  ambientOcclusionRadius 0       # [0, inf)
+  SFFloat  bloomThreshold         -1.0    # [-1, inf)
+  SFFloat  motionBlur             0.0     # [0, inf)
+  SFFloat  noise                  0.0     # [0, 1]
+  SFString noiseMaskUrl           ""      # any string
+  SFNode   lens                   NULL    # {Lens, PROTO}
+  SFNode   focus                  NULL    # {Focus, PROTO}
+  SFNode   zoom                   NULL    # {Zoom, PROTO}
+  SFNode   recognition            NULL    # {Recognition, PROTO}
+  SFNode   lensFlare              NULL    # {LensFlare, PROTO}
 }
 ```
 
@@ -55,6 +57,18 @@ More information on frustums in the corresponding subsection below.
 - The `antiAliasing` field switches on or off (the default) anti-aliasing effect on the camera images.
 Aliasing artifacts can appear as jagged edges (or moiré patterns, strobing, etc.).
 Anti-aliasing is a technique that selectively blurs these jagged edges (and thus makes them look more smooth) in the rendered camera image, similar to an anti-aliasing filter in real camera sensors.
+
+- The `ambientOcclusionRadius` field denotes the radius of geometric occlusion searches in the scene.
+Increasing the radius can increase occlusion from further objects.
+However, at lower quality levels, near-field occlusion can start to disappear as the radius increases.
+This effect is disabled by default on cameras for performance reasons.
+
+- The `bloomThreshold` field denotes the luminosity above which pixels start to "bloom" - i.e. overexpose the camera and leak light around themselves.
+Decreasing the threshold means pixels bloom more easily, as if the camera were more easily overexposed.
+The effect is disabled by default, with a default threshold of `-1`.
+Setting this value to 0 or any positive value re-enables the effect.
+Please note this effect is not physically based, like with Ambient Occlusion (GTAO) or PBR.
+It serves as a good approximation of camera overexposure, however.
 
 - If the `motionBlur` field is greater than 0.0, the image is blurred by the motion of the camera or objects in the field of view.
 It means the image returned is a mix between the current view and the previous images returned by the camera.

--- a/resources/nodes/Camera.wrl
+++ b/resources/nodes/Camera.wrl
@@ -20,22 +20,24 @@ Camera {
   field     MFColor    recognitionColors   []          # colors returned for this Solid by Cameras with a Recognition node
 
   #fields specific to the Camera node:
-  field     SFFloat    fieldOfView     0.785398  # range is (0,pi)
-  field     SFInt32    width           64        # pixel width
-  field     SFInt32    height          64        # pixel height
-  field     SFBool     spherical       FALSE     # to switch between a plane/sphere projection
-  field     SFFloat    near            0.01      # OpenGL near clipping plane (meters)
-  field     SFFloat    far             0.0       # OpenGL far clipping plane (meters)
-  field     SFFloat    exposure        1.0       # Photometric exposure level
-  field     SFBool     antiAliasing    FALSE     # enable anti-aliasing
-  field     SFFloat    motionBlur      0.0       # response time of the image in milliseconds
-  field     SFFloat    noise           0.0       # add a noise to the pixel values
-  field     SFString   noiseMaskUrl    ""        # user-defined noise texture
-  field     SFNode     lens            NULL      # a Lens node
-  field     SFNode     focus           NULL      # a Focus node if the camera has a controllable focus
-  field     SFNode     zoom            NULL      # a Zoom node if the camera has a controllable zoom
-  field     SFNode     recognition     NULL      # a Recognition node if the Camera has recognition capability
-  field     SFNode     lensFlare       NULL      # a LensFlare node
+  field     SFFloat    fieldOfView            0.785398 # range is (0,pi)
+  field     SFInt32    width                  64       # pixel width
+  field     SFInt32    height                 64       # pixel height
+  field     SFBool     spherical              FALSE    # to switch between a plane/sphere projection
+  field     SFFloat    near                   0.01     # OpenGL near clipping plane (meters)
+  field     SFFloat    far                    0.0      # OpenGL far clipping plane (meters)
+  field     SFFloat    exposure               1.0      # Photometric exposure level
+  field     SFBool     antiAliasing           FALSE    # enable anti-aliasing
+  field     SFFloat    ambientOcclusionRadius 2        # radius of ambient occlusion for this camera
+  field     SFFloat    bloomThreshold         21       # threshold of above which pixels bloom for this camera
+  field     SFFloat    motionBlur             0.0      # response time of the image in milliseconds
+  field     SFFloat    noise                  0.0      # add a noise to the pixel values
+  field     SFString   noiseMaskUrl           ""       # user-defined noise texture
+  field     SFNode     lens                   NULL     # a Lens node
+  field     SFNode     focus                  NULL     # a Focus node if the camera has a controllable focus
+  field     SFNode     zoom                   NULL     # a Zoom node if the camera has a controllable zoom
+  field     SFNode     recognition            NULL     # a Recognition node if the Camera has recognition capability
+  field     SFNode     lensFlare              NULL     # a LensFlare node
 
   # hidden fields
   hiddenField SFVec3f linearVelocity  0 0 0   # (m/s) Solid's initial linear velocity

--- a/resources/nodes/Camera.wrl
+++ b/resources/nodes/Camera.wrl
@@ -28,7 +28,7 @@ Camera {
   field     SFFloat    far                    0.0      # OpenGL far clipping plane (meters)
   field     SFFloat    exposure               1.0      # Photometric exposure level
   field     SFBool     antiAliasing           FALSE    # enable anti-aliasing
-  field     SFFloat    ambientOcclusionRadius 2        # radius of ambient occlusion for this camera
+  field     SFFloat    ambientOcclusionRadius 0        # radius of ambient occlusion for this camera
   field     SFFloat    bloomThreshold         21       # threshold of above which pixels bloom for this camera
   field     SFFloat    motionBlur             0.0      # response time of the image in milliseconds
   field     SFFloat    noise                  0.0      # add a noise to the pixel values

--- a/resources/nodes/Camera.wrl
+++ b/resources/nodes/Camera.wrl
@@ -29,7 +29,7 @@ Camera {
   field     SFFloat    exposure               1.0      # Photometric exposure level
   field     SFBool     antiAliasing           FALSE    # enable anti-aliasing
   field     SFFloat    ambientOcclusionRadius 0        # radius of ambient occlusion for this camera
-  field     SFFloat    bloomThreshold         21       # threshold of above which pixels bloom for this camera
+  field     SFFloat    bloomThreshold         -1.0     # threshold of above which pixels bloom for this camera
   field     SFFloat    motionBlur             0.0      # response time of the image in milliseconds
   field     SFFloat    noise                  0.0      # add a noise to the pixel values
   field     SFString   noiseMaskUrl           ""       # user-defined noise texture

--- a/resources/wren/shaders/gtao.frag
+++ b/resources/wren/shaders/gtao.frag
@@ -9,6 +9,7 @@
 uniform sampler2D inputTextures[3];
 
 uniform float radius;
+uniform float flipNormalY;
 uniform vec4 clipInfo;
 uniform vec2 viewportSize;
 uniform vec4 params;
@@ -114,6 +115,9 @@ void main() {
   viewSpaceNormal -= 0.5;
   viewSpaceNormal *= 2.0;
   viewSpaceNormal = normalize(vec3(viewSpaceNormal.xy, -viewSpaceNormal.z));
+
+  if (flipNormalY > 0.0)
+    viewSpaceNormal.y *= -1.0;
 
   // calculate screen-space radius
   float projectedRadius = (radius * clipInfo.z) / viewSpacePosition.z;

--- a/src/webots/nodes/WbCamera.cpp
+++ b/src/webots/nodes/WbCamera.cpp
@@ -155,6 +155,8 @@ void WbCamera::preFinalize() {
   updateNear();
   updateFar();
   updateExposure();
+  updateBloomThreshold();
+  updateAmbientOcclusionRadius();
 }
 
 void WbCamera::postFinalize() {
@@ -743,6 +745,8 @@ void WbCamera::createWrenCamera() {
   applyFocalSettingsToWren();
   applyFarToWren();
   updateExposure();
+  updateBloomThreshold();
+  updateAmbientOcclusionRadius();
 
   updateLensFlare();
   connect(mWrenCamera, &WbWrenCamera::cameraInitialized, this, &WbCamera::updateLensFlare);

--- a/src/webots/nodes/WbCamera.cpp
+++ b/src/webots/nodes/WbCamera.cpp
@@ -89,6 +89,8 @@ void WbCamera::init() {
   mRecognition = findSFNode("recognition");
   mNoiseMaskUrl = findSFString("noiseMaskUrl");
   mAntiAliasing = findSFBool("antiAliasing");
+  mAmbientOcclusionRadius = findSFDouble("ambientOcclusionRadius");
+  mBloomThreshold = findSFDouble("bloomThreshold");
   mLensFlare = findSFNode("lensFlare");
   mFar = findSFDouble("far");
   mExposure = findSFDouble("exposure");
@@ -174,6 +176,8 @@ void WbCamera::postFinalize() {
   connect(mNear, &WbSFDouble::changed, this, &WbCamera::updateNear);
   connect(mFar, &WbSFDouble::changed, this, &WbCamera::updateFar);
   connect(mExposure, &WbSFDouble::changed, this, &WbCamera::updateExposure);
+  connect(mAmbientOcclusionRadius, &WbSFDouble::changed, this, &WbCamera::updateAmbientOcclusionRadius);
+  connect(mBloomThreshold, &WbSFDouble::changed, this, &WbCamera::updateBloomThreshold);
   connect(mAntiAliasing, &WbSFBool::changed, this, &WbAbstractCamera::updateAntiAliasing);
 
   if (lensFlare())
@@ -846,6 +850,20 @@ void WbCamera::updateExposure() {
 
   if (mWrenCamera)
     mWrenCamera->setExposure(mExposure->value());
+}
+
+void WbCamera::updateAmbientOcclusionRadius() {
+  WbFieldChecker::checkDoubleIsNonNegative(this, mAmbientOcclusionRadius, 2.0);
+
+  if (mWrenCamera)
+    mWrenCamera->setAmbientOcclusionRadius(mAmbientOcclusionRadius->value());
+}
+
+void WbCamera::updateBloomThreshold() {
+  WbFieldChecker::checkDoubleIsNonNegativeOrDisabled(this, mBloomThreshold, 21.0, -1.0);
+
+  if (mWrenCamera)
+    mWrenCamera->setBloomThreshold(mBloomThreshold->value());
 }
 
 void WbCamera::updateNoiseMaskUrl() {

--- a/src/webots/nodes/WbCamera.cpp
+++ b/src/webots/nodes/WbCamera.cpp
@@ -181,6 +181,7 @@ void WbCamera::postFinalize() {
   connect(mAmbientOcclusionRadius, &WbSFDouble::changed, this, &WbCamera::updateAmbientOcclusionRadius);
   connect(mBloomThreshold, &WbSFDouble::changed, this, &WbCamera::updateBloomThreshold);
   connect(mAntiAliasing, &WbSFBool::changed, this, &WbAbstractCamera::updateAntiAliasing);
+  connect(WbPreferences::instance(), &WbPreferences::changedByUser, this, &WbCamera::setup);
 
   if (lensFlare())
     lensFlare()->postFinalize();
@@ -767,6 +768,8 @@ void WbCamera::setup() {
 
   updateNoiseMaskUrl();
   updateExposure();
+  updateAmbientOcclusionRadius();
+  updateBloomThreshold();
   connect(mNoiseMaskUrl, &WbSFString::changed, this, &WbCamera::updateNoiseMaskUrl);
 }
 

--- a/src/webots/nodes/WbCamera.hpp
+++ b/src/webots/nodes/WbCamera.hpp
@@ -66,6 +66,8 @@ private:
   WbSFNode *mRecognition;
   WbSFString *mNoiseMaskUrl;
   WbSFBool *mAntiAliasing;
+  WbSFDouble *mAmbientOcclusionRadius;
+  WbSFDouble *mBloomThreshold;
   WbSFNode *mLensFlare;
   WbSFDouble *mFar;
   WbSFDouble *mExposure;
@@ -117,6 +119,8 @@ private slots:
   void updateNear();
   void updateFar();
   void updateExposure();
+  void updateAmbientOcclusionRadius();
+  void updateBloomThreshold();
   void updateNoiseMaskUrl();
   void updateLensFlare();
   void applyFocalSettingsToWren();

--- a/src/webots/nodes/WbViewpoint.cpp
+++ b/src/webots/nodes/WbViewpoint.cpp
@@ -354,7 +354,7 @@ void WbViewpoint::updateAmbientOcclusionRadius() {
 }
 
 void WbViewpoint::updateBloomThreshold() {
-  WbFieldChecker::checkDoubleIsNonNegativeOrDisabled(this, mBloomThreshold, 10.0, -1.0);
+  WbFieldChecker::checkDoubleIsNonNegativeOrDisabled(this, mBloomThreshold, 21.0, -1.0);
 }
 
 WbLensFlare *WbViewpoint::lensFlare() const {

--- a/src/webots/wren/WbWrenCamera.cpp
+++ b/src/webots/wren/WbWrenCamera.cpp
@@ -742,6 +742,7 @@ void WbWrenCamera::setupCameraPostProcessing(int index) {
     const int qualityLevel = WbPreferences::instance()->value("OpenGL/GTAO", 2).toInt();
     if (qualityLevel > 0) {
       mWrenGtao[index]->setHalfResolution(qualityLevel <= 2);
+      mWrenGtao[index]->setFlipNormalY(1.0f);
       mWrenGtao[index]->setup(mCameraViewport[index]);
     }
   }

--- a/src/webots/wren/WbWrenCamera.cpp
+++ b/src/webots/wren/WbWrenCamera.cpp
@@ -608,6 +608,7 @@ void WbWrenCamera::cleanup() {
 
       if (mIsSpherical) {
         wr_texture_delete(WR_TEXTURE(wr_frame_buffer_get_output_texture(mCameraFrameBuffer[i], 0)));
+        wr_texture_delete(WR_TEXTURE(wr_frame_buffer_get_output_texture(mCameraFrameBuffer[i], 1)));
         wr_texture_delete(WR_TEXTURE(wr_frame_buffer_get_depth_texture(mCameraFrameBuffer[i])));
         wr_frame_buffer_delete(mCameraFrameBuffer[i]);
       }

--- a/src/webots/wren/WbWrenCamera.cpp
+++ b/src/webots/wren/WbWrenCamera.cpp
@@ -850,6 +850,12 @@ void WbWrenCamera::updatePostProcessingParameters(int index) {
   if (mWrenBloom[index]->hasBeenSetup())
     mWrenBloom[index]->setThreshold(mBloomThreshold);
 
+  // handle preference ao disable/enable at runtime
+  if (!WbPreferences::instance()->value("OpenGL/GTAO", 2).toInt()) {
+    mWrenGtao[index]->detachFromViewport();
+  } else if (!mWrenGtao[index]->hasBeenSetup())
+    mWrenGtao[index]->setup(mCameraViewport[index]);
+
   if (mWrenGtao[index]->hasBeenSetup()) {
     const int qualityLevel = WbPreferences::instance()->value("OpenGL/GTAO", 2).toInt();
     mWrenGtao[index]->setRadius(mAmbientOcclusionRadius);

--- a/src/webots/wren/WbWrenCamera.cpp
+++ b/src/webots/wren/WbWrenCamera.cpp
@@ -610,9 +610,9 @@ void WbWrenCamera::cleanup() {
         wr_texture_delete(WR_TEXTURE(wr_frame_buffer_get_output_texture(mCameraFrameBuffer[i], 0)));
         wr_texture_delete(WR_TEXTURE(wr_frame_buffer_get_depth_texture(mCameraFrameBuffer[i])));
 
-        if (mType == 'c') 
+        if (mType == 'c')
           wr_texture_delete(WR_TEXTURE(wr_frame_buffer_get_output_texture(mCameraFrameBuffer[i], 1)));
-        
+
         wr_frame_buffer_delete(mCameraFrameBuffer[i]);
       }
     }
@@ -844,7 +844,7 @@ void WbWrenCamera::setAspectRatio(float aspectRatio) {
 void WbWrenCamera::updatePostProcessingParameters(int index) {
   assert(mIsCameraActive[index] && index >= 0 && index < CAMERA_ORIENTATION_COUNT);
 
-  if (mWrenHdr[index]->hasBeenSetup()) 
+  if (mWrenHdr[index]->hasBeenSetup())
     mWrenHdr[index]->setExposure(mExposure);
 
   if (mWrenBloom[index]->hasBeenSetup())

--- a/src/webots/wren/WbWrenCamera.cpp
+++ b/src/webots/wren/WbWrenCamera.cpp
@@ -60,7 +60,7 @@ WbWrenCamera::WbWrenCamera(WrTransform *node, int width, int height, float nearV
   mHeight(height),
   mNear(nearValue),
   mExposure(1.0f),
-  mAmbientOcclusionRadius(2.0f),
+  mAmbientOcclusionRadius(0.0f),
   mBloomThreshold(21.0f),
   mMinRange(minRange),
   mMaxRange(maxRange),
@@ -289,7 +289,7 @@ void WbWrenCamera::setBloomThreshold(float threshold) {
   if (mType != 'c' || threshold == mBloomThreshold)
     return;
 
-  const bool hasStatusChanged = mBloomThreshold == 0.0f || threshold == 0.0f;
+  const bool hasStatusChanged = mBloomThreshold == -1.0f || threshold == -1.0f;
 
   mBloomThreshold = threshold;
   if (hasStatusChanged) {

--- a/src/webots/wren/WbWrenCamera.cpp
+++ b/src/webots/wren/WbWrenCamera.cpp
@@ -850,12 +850,6 @@ void WbWrenCamera::updatePostProcessingParameters(int index) {
   if (mWrenBloom[index]->hasBeenSetup())
     mWrenBloom[index]->setThreshold(mBloomThreshold);
 
-  // handle preference ao disable/enable at runtime
-  if (!WbPreferences::instance()->value("OpenGL/GTAO", 2).toInt()) {
-    mWrenGtao[index]->detachFromViewport();
-  } else if (!mWrenGtao[index]->hasBeenSetup())
-    mWrenGtao[index]->setup(mCameraViewport[index]);
-
   if (mWrenGtao[index]->hasBeenSetup()) {
     const int qualityLevel = WbPreferences::instance()->value("OpenGL/GTAO", 2).toInt();
     mWrenGtao[index]->setRadius(mAmbientOcclusionRadius);

--- a/src/webots/wren/WbWrenCamera.cpp
+++ b/src/webots/wren/WbWrenCamera.cpp
@@ -20,8 +20,10 @@
 #include "WbSimulationState.hpp"
 #include "WbVector2.hpp"
 #include "WbVector4.hpp"
+#include "WbWrenBloom.hpp"
 #include "WbWrenColorNoise.hpp"
 #include "WbWrenDepthOfField.hpp"
+#include "WbWrenGtao.hpp"
 #include "WbWrenHdr.hpp"
 #include "WbWrenLensDistortion.hpp"
 #include "WbWrenMotionBlur.hpp"
@@ -58,6 +60,8 @@ WbWrenCamera::WbWrenCamera(WrTransform *node, int width, int height, float nearV
   mHeight(height),
   mNear(nearValue),
   mExposure(1.0f),
+  mAmbientOcclusionRadius(2.0f),
+  mBloomThreshold(21.0f),
   mMinRange(minRange),
   mMaxRange(maxRange),
   mFieldOfView(fov),
@@ -80,8 +84,10 @@ WbWrenCamera::WbWrenCamera(WrTransform *node, int width, int height, float nearV
   mMotionBlurIntensity(0.0f),
   mNoiseMaskTexture(NULL) {
   for (int i = CAMERA_ORIENTATION_FRONT; i < CAMERA_ORIENTATION_COUNT; ++i) {
+    mWrenBloom[i] = new WbWrenBloom();
     mWrenColorNoise[i] = new WbWrenColorNoise();
     mWrenDepthOfField[i] = new WbWrenDepthOfField();
+    mWrenGtao[i] = new WbWrenGtao();
     mWrenHdr[i] = new WbWrenHdr();
     mWrenMotionBlur[i] = new WbWrenMotionBlur();
     mWrenNoiseMask[i] = new WbWrenNoiseMask();
@@ -98,8 +104,10 @@ WbWrenCamera::~WbWrenCamera() {
   cleanup();
 
   for (int i = CAMERA_ORIENTATION_FRONT; i < CAMERA_ORIENTATION_COUNT; ++i) {
+    delete mWrenBloom[i];
     delete mWrenColorNoise[i];
     delete mWrenDepthOfField[i];
+    delete mWrenGtao[i];
     delete mWrenHdr[i];
     delete mWrenMotionBlur[i];
     delete mWrenNoiseMask[i];
@@ -258,6 +266,32 @@ void WbWrenCamera::setColorNoise(float colorNoise) {
   const bool hasStatusChanged = mColorNoiseIntensity == 0.0f || colorNoise == 0.0f;
 
   mColorNoiseIntensity = colorNoise;
+  if (hasStatusChanged) {
+    cleanup();
+    init();
+  }
+}
+
+void WbWrenCamera::setAmbientOcclusionRadius(float radius) {
+  if (mType != 'c' || radius == mAmbientOcclusionRadius)
+    return;
+
+  const bool hasStatusChanged = mAmbientOcclusionRadius == 0.0f || radius == 0.0f;
+
+  mAmbientOcclusionRadius = radius;
+  if (hasStatusChanged) {
+    cleanup();
+    init();
+  }
+}
+
+void WbWrenCamera::setBloomThreshold(float threshold) {
+  if (mType != 'c' || threshold == mBloomThreshold)
+    return;
+
+  const bool hasStatusChanged = mBloomThreshold == 0.0f || threshold == 0.0f;
+
+  mBloomThreshold = threshold;
   if (hasStatusChanged) {
     cleanup();
     init();
@@ -557,8 +591,10 @@ void WbWrenCamera::cleanup() {
 
   for (int i = CAMERA_ORIENTATION_FRONT; i < CAMERA_ORIENTATION_COUNT; ++i) {
     if (mIsCameraActive[i]) {
+      mWrenBloom[i]->detachFromViewport();
       mWrenColorNoise[i]->detachFromViewport();
       mWrenDepthOfField[i]->detachFromViewport();
+      mWrenGtao[i]->detachFromViewport();
       mWrenHdr[i]->detachFromViewport();
       mWrenMotionBlur[i]->detachFromViewport();
       mWrenNoiseMask[i]->detachFromViewport();
@@ -606,6 +642,8 @@ void WbWrenCamera::setupCamera(int index, int width, int height) {
   wr_viewport_sync_aspect_ratio_with_camera(mCameraViewport[index], false);
   wr_viewport_set_camera(mCameraViewport[index], mCamera[index]);
 
+  mInverseViewMatrix[index] = wr_transform_get_matrix(WR_TRANSFORM(mCamera[index]));
+
   if (isRangeFinderOrLidar) {
     wr_viewport_set_visibility_mask(mCameraViewport[index], WbWrenRenderingContext::VM_WEBOTS_RANGE_CAMERA);
     wr_viewport_enable_skybox(mCameraViewport[index], false);
@@ -624,9 +662,18 @@ void WbWrenCamera::setupCamera(int index, int width, int height) {
     WrTextureRtt *texture = wr_texture_rtt_new();
     wr_texture_set_internal_format(WR_TEXTURE(texture), mTextureFormat);
     wr_frame_buffer_append_output_texture(mCameraFrameBuffer[index], texture);
-    wr_frame_buffer_setup(mCameraFrameBuffer[index]);
     wr_viewport_set_frame_buffer(mCameraViewport[index], mCameraFrameBuffer[index]);
     wr_frame_buffer_set_depth_texture(mCameraFrameBuffer[index], depthRenderTexture);
+
+    // needed to store normals for ambient occlusion
+    if (mType == 'c') {
+      WrTextureRtt *normalTexture = wr_texture_rtt_new();
+      wr_texture_rtt_enable_initialize_data(normalTexture, true);
+      wr_texture_set_internal_format(WR_TEXTURE(normalTexture), WR_TEXTURE_INTERNAL_FORMAT_RGB8);
+      wr_frame_buffer_append_output_texture(mCameraFrameBuffer[index], normalTexture);
+    }
+
+    wr_frame_buffer_setup(mCameraFrameBuffer[index]);
   } else {  // otherwise, we use the result framebuffer directly, so no extra texture setup
     wr_viewport_set_frame_buffer(mCameraViewport[index], mResultFrameBuffer);
     wr_frame_buffer_set_depth_texture(mResultFrameBuffer, depthRenderTexture);
@@ -686,6 +733,17 @@ void WbWrenCamera::setupSphericalSubCameras() {
 
 void WbWrenCamera::setupCameraPostProcessing(int index) {
   assert(mIsCameraActive[index] && index >= 0 && index < CAMERA_ORIENTATION_COUNT);
+
+  if (mBloomThreshold != -1.0f && mType == 'c')
+    mWrenBloom[index]->setup(mCameraViewport[index]);
+
+  if (mAmbientOcclusionRadius != 0.0f && mType == 'c') {
+    const int qualityLevel = WbPreferences::instance()->value("OpenGL/GTAO", 2).toInt();
+    if (qualityLevel > 0) {
+      mWrenGtao[index]->setHalfResolution(qualityLevel <= 2);
+      mWrenGtao[index]->setup(mCameraViewport[index]);
+    }
+  }
 
   // lens distortion
   if (mIsLensDistortionEnabled) {
@@ -781,8 +839,19 @@ void WbWrenCamera::setAspectRatio(float aspectRatio) {
 void WbWrenCamera::updatePostProcessingParameters(int index) {
   assert(mIsCameraActive[index] && index >= 0 && index < CAMERA_ORIENTATION_COUNT);
 
-  if (mWrenHdr[index]->hasBeenSetup())
+  if (mWrenHdr[index]->hasBeenSetup()) 
     mWrenHdr[index]->setExposure(mExposure);
+
+  if (mWrenBloom[index]->hasBeenSetup())
+    mWrenBloom[index]->setThreshold(mBloomThreshold);
+
+  if (mWrenGtao[index]->hasBeenSetup()) {
+    int qualityLevel = WbPreferences::instance()->value("OpenGL/GTAO", 2).toInt();
+    mWrenGtao[index]->setRadius(mAmbientOcclusionRadius);
+    mWrenGtao[index]->setQualityLevel(qualityLevel);
+    mWrenGtao[index]->applyOldInverseViewMatrixToWren();
+    mWrenGtao[index]->copyNewInverseViewMatrix(mInverseViewMatrix[index]);
+  }
 
   if (mIsLensDistortionEnabled) {
     mWrenLensDistortion[index]->setCenter(mLensDistortionCenter.x(), mLensDistortionCenter.y());

--- a/src/webots/wren/WbWrenCamera.cpp
+++ b/src/webots/wren/WbWrenCamera.cpp
@@ -851,7 +851,7 @@ void WbWrenCamera::updatePostProcessingParameters(int index) {
     mWrenBloom[index]->setThreshold(mBloomThreshold);
 
   if (mWrenGtao[index]->hasBeenSetup()) {
-    int qualityLevel = WbPreferences::instance()->value("OpenGL/GTAO", 2).toInt();
+    const int qualityLevel = WbPreferences::instance()->value("OpenGL/GTAO", 2).toInt();
     mWrenGtao[index]->setRadius(mAmbientOcclusionRadius);
     mWrenGtao[index]->setQualityLevel(qualityLevel);
     mWrenGtao[index]->applyOldInverseViewMatrixToWren();

--- a/src/webots/wren/WbWrenCamera.cpp
+++ b/src/webots/wren/WbWrenCamera.cpp
@@ -608,8 +608,11 @@ void WbWrenCamera::cleanup() {
 
       if (mIsSpherical) {
         wr_texture_delete(WR_TEXTURE(wr_frame_buffer_get_output_texture(mCameraFrameBuffer[i], 0)));
-        wr_texture_delete(WR_TEXTURE(wr_frame_buffer_get_output_texture(mCameraFrameBuffer[i], 1)));
         wr_texture_delete(WR_TEXTURE(wr_frame_buffer_get_depth_texture(mCameraFrameBuffer[i])));
+
+        if (mType == 'c') 
+          wr_texture_delete(WR_TEXTURE(wr_frame_buffer_get_output_texture(mCameraFrameBuffer[i], 1)));
+        
         wr_frame_buffer_delete(mCameraFrameBuffer[i]);
       }
     }

--- a/src/webots/wren/WbWrenCamera.hpp
+++ b/src/webots/wren/WbWrenCamera.hpp
@@ -31,8 +31,10 @@ struct WrTexture;
 struct WrTexture2d;
 struct WrViewport;
 
+class WbWrenBloom;
 class WbWrenColorNoise;
 class WbWrenDepthOfField;
+class WbWrenGtao;
 class WbWrenHdr;
 class WbWrenLensDistortion;
 class WbWrenMotionBlur;
@@ -74,6 +76,8 @@ public:
   void setNear(float nearValue);
   void setFar(float farValue);
   void setExposure(float exposure);
+  void setAmbientOcclusionRadius(float radius);
+  void setBloomThreshold(float threshold);
   void setMinRange(float minRange);
   void setMaxRange(float maxRange);
   void setFieldOfView(float fov);
@@ -127,6 +131,8 @@ private:
   int mHeight;
   float mNear;
   float mExposure;
+  float mAmbientOcclusionRadius;
+  float mBloomThreshold;
   float mMinRange;
   float mMaxRange;
   float mFieldOfView;
@@ -159,15 +165,18 @@ private:
   WrFrameBuffer *mResultFrameBuffer;
   WrTextureInternalFormat mTextureFormat;
 
+  WbWrenBloom *mWrenBloom[CAMERA_ORIENTATION_COUNT];
   WbWrenColorNoise *mWrenColorNoise[CAMERA_ORIENTATION_COUNT];
   WbWrenDepthOfField *mWrenDepthOfField[CAMERA_ORIENTATION_COUNT];
-  WbWrenLensDistortion *mWrenLensDistortion[CAMERA_ORIENTATION_COUNT];
+  WbWrenGtao *mWrenGtao[CAMERA_ORIENTATION_COUNT];
   WbWrenHdr *mWrenHdr[CAMERA_ORIENTATION_COUNT];
+  WbWrenLensDistortion *mWrenLensDistortion[CAMERA_ORIENTATION_COUNT];
   WbWrenMotionBlur *mWrenMotionBlur[CAMERA_ORIENTATION_COUNT];
   WbWrenNoiseMask *mWrenNoiseMask[CAMERA_ORIENTATION_COUNT];
   WbWrenRangeNoise *mWrenRangeNoise[CAMERA_ORIENTATION_COUNT];
   WbWrenRangeQuantization *mWrenRangeQuantization[CAMERA_ORIENTATION_COUNT];
   WbWrenSmaa *mWrenSmaa[CAMERA_ORIENTATION_COUNT];
+  const float *mInverseViewMatrix[CAMERA_ORIENTATION_COUNT];
 
   float mColorNoiseIntensity;
   float mRangeNoiseIntensity;

--- a/src/webots/wren/WbWrenGtao.cpp
+++ b/src/webots/wren/WbWrenGtao.cpp
@@ -34,6 +34,7 @@ WbWrenGtao::WbWrenGtao() :
   mFov(0.78f),
   mRadius(2.0),
   mHalfResolution(false),
+  mFlipNormalY(0.0f),
   mFrameCounter(0) {
   mClipInfo[0] = mClipInfo[1] = mClipInfo[2] = mClipInfo[3] = 0.0f;
   mParams[0] = mParams[1] = mParams[2] = mParams[3] = 0.0f;
@@ -128,6 +129,12 @@ void WbWrenGtao::setQualityLevel(int qualityLevel) {
   applyParametersToWren();
 }
 
+void WbWrenGtao::setFlipNormalY(float flip) {
+  mFlipNormalY = flip;
+
+  applyParametersToWren();
+}
+
 void WbWrenGtao::copyNewInverseViewMatrix(const float *inverseViewMatrix) {
   memcpy(mPreviousInverseViewMatrix, inverseViewMatrix, sizeof(float) * 16);
 }
@@ -154,6 +161,8 @@ void WbWrenGtao::applyParametersToWren() {
   wr_post_processing_effect_pass_set_program_parameter(mGtaoPass, "params", reinterpret_cast<const char *>(&mParams));
 
   wr_post_processing_effect_pass_set_program_parameter(mGtaoPass, "radius", reinterpret_cast<const char *>(&mRadius));
+
+  wr_post_processing_effect_pass_set_program_parameter(mGtaoPass, "flipNormalY", reinterpret_cast<const char *>(&mFlipNormalY));
 
   ++mFrameCounter;
 

--- a/src/webots/wren/WbWrenGtao.hpp
+++ b/src/webots/wren/WbWrenGtao.hpp
@@ -32,6 +32,7 @@ public:
   void setRadius(float radius);
   void setQualityLevel(int qualityLevel);
   void setHalfResolution(bool halfResolution) { mHalfResolution = halfResolution; }
+  void setFlipNormalY(float flip);
   void copyNewInverseViewMatrix(const float *inverseViewMatrix);
   void applyOldInverseViewMatrixToWren();
 
@@ -47,6 +48,7 @@ private:
   float mOffsets[4];
   float mParams[4];
   bool mHalfResolution;
+  float mFlipNormalY;
   float mPreviousInverseViewMatrix[16];
   int mFrameCounter;
 };

--- a/src/webots/wren/WbWrenShaders.cpp
+++ b/src/webots/wren/WbWrenShaders.cpp
@@ -442,6 +442,10 @@ WrShaderProgram *WbWrenShaders::gtaoShader() {
     wr_shader_program_create_custom_uniform(gShaders[SHADER_GTAO], "radius", WR_SHADER_PROGRAM_UNIFORM_TYPE_FLOAT,
                                             reinterpret_cast<const char *>(&radius));
 
+    const float flipNormalY = 0.0;
+    wr_shader_program_create_custom_uniform(gShaders[SHADER_GTAO], "flipNormalY", WR_SHADER_PROGRAM_UNIFORM_TYPE_FLOAT,
+                                            reinterpret_cast<const char *>(&flipNormalY));
+
     ::buildShader(gShaders[SHADER_GTAO], QFileInfo("gl:shaders/pass_through.vert"), QFileInfo("gl:shaders/gtao.frag"));
   }
 

--- a/src/wren/Viewport.cpp
+++ b/src/wren/Viewport.cpp
@@ -186,6 +186,9 @@ namespace wren {
     if (mPolygonMode != WR_VIEWPORT_POLYGON_MODE_FILL)
       return;
 
+    if (mCamera->flipY())
+      glstate::setFrontFace(GL_CCW);
+
     if (mAmbientOcclusionEffect) {
       if (mFrameBuffer) {
         mAmbientOcclusionEffect->setInputFrameBuffer(mFrameBuffer);
@@ -198,6 +201,9 @@ namespace wren {
 
       mAmbientOcclusionEffect->apply();
     }
+
+    if (mCamera->flipY())
+      glstate::setFrontFace(GL_CW);
   }
 
   void Viewport::applyAntiAliasing() {


### PR DESCRIPTION
This PR adds advanced Post-Processing (GTAO & Bloom) onto color cameras in Webots.
The `ambientOcclusionRadius` field is 0 by default (disabling the effect) for performance reasons.