### PR TITLE
Fixed Compilation of Java Controller when Swig is not Installed.

### DIFF
--- a/resources/Makefile.java.include
+++ b/resources/Makefile.java.include
@@ -96,6 +96,9 @@ endif
 ifeq ($(JAVA_HOME),)
 release debug profile:
 	@echo -e "# \033[0;33mJava not installed or 'JAVA_HOME' not set, skipping Java API\033[0m"
+else ifeq (,$(wildcard $(WEBOTS_HOME_PATH)/lib/java))
+release debug profile:
+	@echo -e "# \033[0;33mJava library not compiled, skipping Java API\033[0m"
 else
 release debug profile:
 	@javac $(JAVAC_OPTS) *.java


### PR DESCRIPTION
On windows if the `src/install_scripts/msys64_installer.sh` is not run with the `--all` argument but the `JAVA_HOME` environment variable is set, the correct warning is displayed when trying to compile the Java API but not when trying to compile the controllers.