### PR TITLE
Fix Emitter-Receiver Matlab API

### DIFF
--- a/docs/reference/emitter.md
+++ b/docs/reference/emitter.md
@@ -205,6 +205,12 @@ Here is an example of sending a Java string in a way that is compatible with a C
 > }
 > ```
 
+> **Note** [Matlab]: If you want to send strings you have to convert them to unsigned integer arrays:
+
+> ```matlab
+>   wb_emitter_send(emitter, uint8('Hello World'));
+> ```
+
 ---
 
 #### `wb_emitter_set_channel`

--- a/docs/reference/emitter.md
+++ b/docs/reference/emitter.md
@@ -205,6 +205,8 @@ Here is an example of sending a Java string in a way that is compatible with a C
 > }
 > ```
 
+<!-- -->
+
 > **Note** [Matlab]: If you want to send strings you have to convert them to unsigned integer arrays:
 
 > ```matlab

--- a/docs/reference/emitter.md
+++ b/docs/reference/emitter.md
@@ -207,7 +207,6 @@ Here is an example of sending a Java string in a way that is compatible with a C
 
 <!-- -->
 
-
 > **Note** [Matlab]: If you want to send strings you have to convert them to unsigned integer arrays:
 
 > ```matlab

--- a/docs/reference/emitter.md
+++ b/docs/reference/emitter.md
@@ -207,6 +207,7 @@ Here is an example of sending a Java string in a way that is compatible with a C
 
 <!-- -->
 
+
 > **Note** [Matlab]: If you want to send strings you have to convert them to unsigned integer arrays:
 
 > ```matlab

--- a/docs/reference/receiver.md
+++ b/docs/reference/receiver.md
@@ -358,7 +358,7 @@ public class Receiver extends Device {
 
 ```matlab
 size = wb_receiver_get_data_size(tag)
-data = wb_receiver_get_data(tag)
+data = wb_receiver_get_data(tag, type)
 ```
 
 %tab-end
@@ -401,7 +401,7 @@ Here is an example for getting the data:
 
 <!-- -->
 
-> **Note** [MATLAB]: The MATLAB `wb_receiver_get_data` function returns a MATLAB *libpointer*.
+> **Note** [MATLAB]: The MATLAB `wb_receiver_get_data` function returns a MATLAB *libpointer* if the `type` argument is not set (type should be `uint8`, `double` or `string`).
 The receiving code is responsible for extracting the data from the *libpointer* using MATLAB's `setdatatype` and `get` functions.
 Here is an example on how to send and receive a 2x3 MATLAB matrix.
 


### PR DESCRIPTION
The Matlab Emitter-Receiver API is incomplete.

https://www.cyberbotics.com/doc/reference/emitter?version=fix-emitter-reciever-matlab-api#emitter-functions