### PR TITLE
Fixed Missleading Changelog entry

### DIFF
--- a/change_logs/ChangeLog.html
+++ b/change_logs/ChangeLog.html
@@ -50,8 +50,7 @@ Released on December 17th, 2018
 <li>Windows: upgraded to Qt 5.12.0.</li>
 <li>macOS: upgraded to Qt 5.11.2.</li>
 <li><font color="red">macOS: Added support for macOS 10.14. Dropped support of the obsolete libstdc++ and the i386 architecture from libController and derivated libraries.</font></li>
-<li><font color="red">Windows: upgraded default Python version to 3.7</font></li>
-<li><font color="red">macOS: upgraded Python 3 precompiled packages to Python 3.7</font></li>
+<li><font color="red">macOS, Windows: upgraded Python 3 precompiled packages to Python 3.7</font></li>
 </ul>
 <li><b>Enhancements</b></li>
 <ul>


### PR DESCRIPTION
This entry was duplicated and could let the user think that we dropped Python 2.7