### PR TITLE
Add gdb Package to MSYS Installer as Optional Package

### DIFF
--- a/src/install_scripts/msys64_installer.sh
+++ b/src/install_scripts/msys64_installer.sh
@@ -33,6 +33,7 @@ declare -a OPTIONAL_PACKAGES=(
   "mingw-w64-i686-libpng"     # libController (32 bit)
   "mingw-w64-x86_64-clang"    # coding style tests
   "mingw-w64-x86_64-cppcheck" # coding style tests
+  "mingw-w64-x86_64-gdb"      # for debugging
 )
 
 if [ "$1" == "--all" ]; then

--- a/src/install_scripts/msys64_installer.sh
+++ b/src/install_scripts/msys64_installer.sh
@@ -33,7 +33,7 @@ declare -a OPTIONAL_PACKAGES=(
   "mingw-w64-i686-libpng"     # libController (32 bit)
   "mingw-w64-x86_64-clang"    # coding style tests
   "mingw-w64-x86_64-cppcheck" # coding style tests
-  "mingw-w64-x86_64-gdb"      # for debugging
+  "mingw-w64-x86_64-gdb"      # debugging
 )
 
 if [ "$1" == "--all" ]; then

--- a/src/install_scripts/msys64_installer.sh
+++ b/src/install_scripts/msys64_installer.sh
@@ -31,12 +31,17 @@ declare -a OPTIONAL_PACKAGES=(
   "mingw-w64-i686-gcc"        # libController (32 bit)
   "mingw-w64-i686-libtiff"    # libController (32 bit)
   "mingw-w64-i686-libpng"     # libController (32 bit)
+)
+
+declare -a DEVELOPMENT_PACKAGES=(
   "mingw-w64-x86_64-clang"    # coding style tests
   "mingw-w64-x86_64-cppcheck" # coding style tests
   "mingw-w64-x86_64-gdb"      # debugging
 )
 
-if [ "$1" == "--all" ]; then
+if [ "$1" == "--dev" ]; then
+  declare -a PACKAGES=("${BASE_PACKAGES[@]}" "${OPTIONAL_PACKAGES[@]}" "${DEVELOPMENT_PACKAGES[@]}")
+elif [ "$1" == "--all" ]; then
   declare -a PACKAGES=("${BASE_PACKAGES[@]}" "${OPTIONAL_PACKAGES[@]}")
 else
   declare -a PACKAGES=("${BASE_PACKAGES[@]}")


### PR DESCRIPTION
It is very useful to have GDB installed (I am always ending up installing it manually), at least when the msys installer is launched with the `--all` argument.