### PR TITLE
Add Missing Muscle in nodes-and-api-functions Page

### DIFF
--- a/docs/reference/nodes-and-api-functions.md
+++ b/docs/reference/nodes-and-api-functions.md
@@ -56,6 +56,7 @@
 - [Material](material.md)
 - [Motor](motor.md)
 - [Mouse](mouse.md)
+- [Muscle](muscle.md)
 - [PBRAppearance](pbrappearance.md)
 - [Pen](pen.md)
 - [Physics](physics.md)


### PR DESCRIPTION
The muscle node is present in the menu but not in the list of nodes of this page.