### PR TITLE
Fixed gcc7/cygwin flush of stdout/stderr

### DIFF
--- a/change_logs/ChangeLog.html
+++ b/change_logs/ChangeLog.html
@@ -21,6 +21,7 @@ Released on XXX XXth, 2019
 </ul>
 <li><b>Bug fixes</b></li>
 <ul>
+<li>Windows: fixed flush of stdout and stderr for robot controllers.</li>
 <li>Fixed crash with the Python API when getting a Camera, Lidar or RangeFinder image at first step (thanks to Farinaz).</li>
 <li>Fixed crash when exporting some worlds to VRML97.</li>
 <li>Fixed crash at startup when using a low-end GPU.</li>

--- a/include/controller/c/webots/robot.h
+++ b/include/controller/c/webots/robot.h
@@ -67,7 +67,9 @@ int wb_robot_init_msvc();  // internally, this function just calls wb_robot_init
 
 int wb_robot_step(int duration);  // milliseconds
 
-#ifdef __CYGWIN__  // in that case, we need to flush explicitly the stdout/stdin streams otherwise they are buffered
+#ifdef __CYGWIN__  // In that case, we need to flush explicitly the stdout/stdin streams otherwise they are buffered
+// We cannot call fflush from the libController as libController is compiled with gcc8 and won't flush the stdout/stderr
+// of a gcc7 (cygwin) compiled binary. Therefore, we need to perform the fflush in a gcc7 compiled code, e.g., in a macro here.
 #define wb_robot_step(d) (fflush(NULL) ? wb_robot_step(d) : wb_robot_step(d))
 #endif
 

--- a/include/controller/c/webots/robot.h
+++ b/include/controller/c/webots/robot.h
@@ -65,7 +65,12 @@ int wb_robot_init_msvc();  // internally, this function just calls wb_robot_init
 #define wb_robot_init() (setvbuf(stdout, NULL, _IONBF, 0), setvbuf(stderr, NULL, _IONBF, 0), wb_robot_init_msvc())
 #endif
 
-int wb_robot_step(int duration);                                                                // milliseconds
+int wb_robot_step(int duration);  // milliseconds
+
+#ifdef __CYGWIN__  // in that case, we need to flush explicitly the stdout/stdin streams otherwise they are buffered
+#define wb_robot_step(d) (fflush(NULL) ? wb_robot_step(d) : wb_robot_step(d))
+#endif
+
 WbUserInputEvent wb_robot_wait_for_user_input_event(WbUserInputEvent event_type, int timeout);  // milliseconds
 void wb_robot_cleanup();
 double wb_robot_get_time();


### PR DESCRIPTION
Fixes #124.
I tested with C and C++ controllers with GCC 7 and GCC 8 and it worked in all cases.