### PR TITLE
Fix macOS build

### DIFF
--- a/src/webots/core/WbSysInfo.cpp
+++ b/src/webots/core/WbSysInfo.cpp
@@ -550,8 +550,6 @@ int WbSysInfo::intelGPUGeneration(QOpenGLFunctions *gl) {
   return 0;
 }
 
-#endif
-
 bool WbSysInfo::isAmdLowEndGpu(QOpenGLFunctions *gl) {
   // https://pci-ids.ucw.cz/read/PC/1002
   quint32 id = gpuDeviceId(gl);
@@ -577,3 +575,5 @@ bool WbSysInfo::isAmdLowEndGpu(QOpenGLFunctions *gl) {
     return true;
   return false;
 }
+
+#endif


### PR DESCRIPTION
`WbSysInfo::isAmdLowEndGpu()` should not be defined on macOS, otherwise it leads to build issues:

```
core/WbSysInfo.cpp:555:17: error: out-of-line definition of 'isAmdLowEndGpu' does not match any declaration in namespace 'WbSysInfo'
bool WbSysInfo::isAmdLowEndGpu(QOpenGLFunctions *gl) {
                ^~~~~~~~~~~~~~
# compiling gui/WbWheelEvent.cpp
core/WbSysInfo.cpp:557:16: error: use of undeclared identifier 'gpuDeviceId'
  quint32 id = gpuDeviceId(gl);
               ^
2 errors generated.
```