### PR TITLE
Add a script to clean Webots preferences

### DIFF
--- a/src/bin/clean_webots_preferences.sh
+++ b/src/bin/clean_webots_preferences.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Cleanup all Webots preferences.
+
+if [ "$(uname)" == "Darwin" ]; then
+  for n in `find $HOME/Library/Preferences -name com.cyberbotics.* | sed 's:.*/::;s:.plist::'`; do
+    echo Remove "$n";
+    defaults remove $n;
+    rm $HOME/Library/Preferences/$n.plist;
+  done
+else
+  echo "Unsupported OS"
+  exit 1
+fi


### PR DESCRIPTION
Cleaning the Webots preferences is a difficult task (especially on macOS and Windows). I think it would deserve a helper script to do so.