### PR TITLE
Fix compilation of WbTelemetry.cpp on Windows

### DIFF
--- a/src/webots/core/WbTelemetry.cpp
+++ b/src/webots/core/WbTelemetry.cpp
@@ -21,6 +21,8 @@
 
 #include <QtNetwork/QNetworkReply>
 
+#include <cassert>
+
 void WbTelemetry::send(const QString &file, const QString &operation) {
   static WbTelemetry telemetry;
   telemetry.sendRequest(file, operation);


### PR DESCRIPTION
I just reinstalled the development system on Windows following the instructions on the wiki and Webots compilation fails because of the missing include of `cassert`.
