### PR TITLE
Added a warning if Webots is launched with the --stream and not the --batch option

### DIFF
--- a/src/webots/gui/WbGuiApplication.cpp
+++ b/src/webots/gui/WbGuiApplication.cpp
@@ -119,7 +119,7 @@ void WbGuiApplication::parseArguments() {
   // faster when copied according to Qt's doc
   QStringList args = arguments();
   bool logPerformanceMode = false;
-  bool batch = false;
+  bool batch = false, stream = false;
 
   const int size = args.size();
   for (int i = 1; i < size; ++i) {
@@ -160,8 +160,7 @@ void WbGuiApplication::parseArguments() {
     else if (arg == "--enable-x3d-meta-file-export")
       WbWorld::enableX3DMetaFileExport();
     else if (arg.startsWith("--stream")) {
-      if (!batch)
-        cout << "Warning: you should also use --batch (in addition to --stream) for production." << endl;
+      stream = true;
       QString serverArgument;
       int equalCharacterIndex = arg.indexOf('=');
       if (equalCharacterIndex != -1) {
@@ -219,6 +218,9 @@ void WbGuiApplication::parseArguments() {
       }
     }
   }
+
+  if (stream && !batch)
+    cout << "Warning: you should also use --batch (in addition to --stream) for production." << endl;
 
   if (logPerformanceMode) {
     WbPerformanceLog::enableSystemInfoLog(mTask == SYSINFO);

--- a/src/webots/gui/WbGuiApplication.cpp
+++ b/src/webots/gui/WbGuiApplication.cpp
@@ -119,6 +119,7 @@ void WbGuiApplication::parseArguments() {
   // faster when copied according to Qt's doc
   QStringList args = arguments();
   bool logPerformanceMode = false;
+  bool batch = false;
 
   const int size = args.size();
   for (int i = 1; i < size; ++i) {
@@ -144,9 +145,10 @@ void WbGuiApplication::parseArguments() {
       mTask = SYSINFO;
     else if (arg == "--version")
       mTask = VERSION;
-    else if (arg == "--batch")
+    else if (arg == "--batch") {
+      batch = true;
       WbMessageBox::disable();
-    else if (arg.startsWith("--update-proto-cache")) {
+    } else if (arg.startsWith("--update-proto-cache")) {
       QStringList items = arg.split('=');
       if (items.size() > 1)
         mTaskArgument = items[1];
@@ -158,6 +160,8 @@ void WbGuiApplication::parseArguments() {
     else if (arg == "--enable-x3d-meta-file-export")
       WbWorld::enableX3DMetaFileExport();
     else if (arg.startsWith("--stream")) {
+      if (!batch)
+        cout << "Warning: you should also use --batch (in addition to --stream) for production." << endl;
       QString serverArgument;
       int equalCharacterIndex = arg.indexOf('=');
       if (equalCharacterIndex != -1) {


### PR DESCRIPTION
It is safer and more efficient to run Webots in batch mode when using it as a simulation streaming server. Adding a warning in case the batch mode is not enabled in streaming mode should save users from troubles, like the "new version available" pop-up window preventing Webots from running in streaming mode until a user press the close button.