### PR TITLE
Fix Connectors with SolidMergers

### DIFF
--- a/src/webots/nodes/WbConnector.cpp
+++ b/src/webots/nodes/WbConnector.cpp
@@ -331,18 +331,14 @@ void WbConnector::snapRotation(WbConnector *other, const WbVector3 &y1, const Wb
 }
 
 // return the vrml origin ([0 0 0] point) of the connector in world (global) coordinate system
-// this requires to translate by physics->centeroOfMass and rotate by current matrix
-// (in fact we would also need to rotate according to
-// physics->orientation but this was left out for the moment)
 void WbConnector::getOriginInWorldCoordinates(dReal out[3]) const {
   dBodyID b = upperSolid()->bodyMerger();
   assert(upperSolid()->physics() && b);
 
-  // translate from VRLM to body coordinate system
-  WbVector3 origin = translation() - upperSolid()->centerOfMass();
-
-  // transform from dBody CS to global CS (world)
-  dBodyGetRelPointPos(b, origin[0], origin[1], origin[2], out);
+  const WbVector3 &globalTranslation = matrix().translation();
+  out[0] = globalTranslation[0];
+  out[1] = globalTranslation[1];
+  out[2] = globalTranslation[2];
 }
 
 // shift both connectors (parent) bodies such that the connectors VRML origins match

--- a/src/webots/nodes/WbConnector.cpp
+++ b/src/webots/nodes/WbConnector.cpp
@@ -332,9 +332,6 @@ void WbConnector::snapRotation(WbConnector *other, const WbVector3 &y1, const Wb
 
 // return the vrml origin ([0 0 0] point) of the connector in world (global) coordinate system
 void WbConnector::getOriginInWorldCoordinates(dReal out[3]) const {
-  dBodyID b = upperSolid()->bodyMerger();
-  assert(upperSolid()->physics() && b);
-
   const WbVector3 &globalTranslation = matrix().translation();
   out[0] = globalTranslation[0];
   out[1] = globalTranslation[1];
@@ -349,20 +346,8 @@ void WbConnector::snapOrigins(WbConnector *other) {
 
   // get positions of connector 1 and 2
   dVector3 p1, p2;
-  if (b1)
-    getOriginInWorldCoordinates(p1);
-  else {
-    const WbVector3 translation = matrix().translation();
-    for (int i = 0; i < 3; ++i)
-      p1[i] = translation[i];
-  }
-  if (b2)
-    other->getOriginInWorldCoordinates(p2);
-  else {
-    const WbVector3 translation = other->matrix().translation();
-    for (int i = 0; i < 3; ++i)
-      p2[i] = translation[i];
-  }
+  getOriginInWorldCoordinates(p1);
+  other->getOriginInWorldCoordinates(p2);
 
   // retrieve current body positions
   const dReal *d1 = b1 ? dBodyGetPosition(b1) : matrix().translation().ptr();

--- a/tests/physics/controllers/connector_static_autolock/connector_static_autolock.c
+++ b/tests/physics/controllers/connector_static_autolock/connector_static_autolock.c
@@ -30,7 +30,7 @@ int main(int argc, char **argv) {
     wb_robot_step(TIME_STEP);
 
   const double *position = wb_supervisor_node_get_position(solid);
-  ts_assert_vec3_in_delta(position[0], position[1], position[2], 0.25, 0.2, 0.0, 0.02,
+  ts_assert_vec3_in_delta(position[0], position[1], position[2], 0.25, 0.2, 0.0, 0.001,
                           "Solid is not at the expected position ([%lf, %lf, %lf] instead of [0.25, 0.2, 0.0]).", position[0],
                           position[1], position[2]);
 

--- a/tests/physics/controllers/connector_static_autolock/connector_static_autolock.c
+++ b/tests/physics/controllers/connector_static_autolock/connector_static_autolock.c
@@ -30,7 +30,7 @@ int main(int argc, char **argv) {
     wb_robot_step(TIME_STEP);
 
   const double *position = wb_supervisor_node_get_position(solid);
-  ts_assert_vec3_in_delta(position[0], position[1], position[2], 0.25, 0.2, 0.0, 0.01,
+  ts_assert_vec3_in_delta(position[0], position[1], position[2], 0.25, 0.2, 0.0, 0.02,
                           "Solid is not at the expected position ([%lf, %lf, %lf] instead of [0.25, 0.2, 0.0]).", position[0],
                           position[1], position[2]);
 

--- a/tests/physics/worlds/connector_static_autolock.wbt
+++ b/tests/physics/worlds/connector_static_autolock.wbt
@@ -1,6 +1,7 @@
 #VRML_SIM R2019a utf8
 WorldInfo {
   title "Auto lock static connectors"
+  basicTimeStep 8
 }
 Viewpoint {
   orientation 0.10833828102060336 0.9839846395851807 0.1415522727684823 4.121503424005624
@@ -47,7 +48,6 @@ DEF ACTIVE_ROBOT Robot {
 }
 DEF SOLID Solid {
   translation 0.247 0.19999999999999996 0
-  rotation 0.8913161249534984 -0.43793373078283837 0.1173439936277272 5.699130699799398
   children [
     DEF BODY Transform {
       children [


### PR DESCRIPTION
When Connectors are used inside a SolidMerger, the connection (snapOrigin) is shifted because the rotations between the SolidMerger and the Connector are dealt in a too simplistic way.