### PR TITLE
Fix tire creaseAngle

### DIFF
--- a/projects/vehicles/protos/abstract/VehicleWheel.proto
+++ b/projects/vehicles/protos/abstract/VehicleWheel.proto
@@ -220,7 +220,7 @@ PROTO VehicleWheel [
                 %{ end }%
               %{ end }%
             ]
-            creaseAngle %{= 2 * math.pi / subdivision + 0.01 }%
+            creaseAngle 1.5
           }
         }
         DEF RIM Group {


### PR DESCRIPTION
Edges should be invisible on a tire. The current computation is complex and do not take into consideration the tire curvature.

| develop | this branch |
| --- | --- |
| ![wheel before](https://user-images.githubusercontent.com/866788/53549503-9a9f9a80-3b34-11e9-92b0-58074b35c7b8.png) | ![wheel after](https://user-images.githubusercontent.com/866788/53549501-9a9f9a80-3b34-11e9-81a7-3ddd963b03dd.png) |
| ![session_1_wheel_before](https://user-images.githubusercontent.com/866788/53549500-9a9f9a80-3b34-11e9-89d2-4e5f903b341a.png) | ![session_1_wheel_after](https://user-images.githubusercontent.com/866788/53549498-9a9f9a80-3b34-11e9-9aa6-985e6a0f8a0b.png) |