### PR TITLE
webots.js: remove initialization of showRevert and showQuit in wrong method

### DIFF
--- a/resources/web/wwi/webots.js
+++ b/resources/web/wwi/webots.js
@@ -1604,10 +1604,6 @@ webots.Server = function(url, view, onready) {
         webots.User2Name = '';
       if (typeof webots.CustomData === 'undefined')
         webots.CustomData = '';
-      if (typeof webots.showRevert === 'undefined')
-        webots.showRevert = false;
-      if (typeof webots.showQuit === 'undefined')
-        webots.showQuit = true;
       this.send('{ "init" : [ "' + host + '", "' + that.project + '", "' + that.worldFile + '", "' +
                 webots.User1Id + '", "' + webots.User1Name + '", "' + webots.User1Authentication + '", "' +
                 webots.User2Id + '", "' + webots.User2Name + '", "' + webots.CustomData + '" ] }');


### PR DESCRIPTION
Given that `webots.showRevert` and `show.Quit` properties are not set to the simulation server, they doesn't have to be initialized in `webots.Server` constructor.

In any case this initialization was fixed in #241 and it is no longer needed.