### PR TITLE
Change Appearances Licenses to Apache 2.0

### DIFF
--- a/docs/guide/appearances.md
+++ b/docs/guide/appearances.md
@@ -24,8 +24,8 @@ Asphalt {
 
 > **File location**: "WEBOTS\_HOME/projects/appearances/protos/Asphalt.proto"
 
-> **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
-[More information.](https://cyberbotics.com/webots_assets_license)
+> **License**: Apache License 2.0
+[More information.](http://www.apache.org/licenses/LICENSE-2.0)
 
 ### Asphalt Field Summary
 
@@ -60,8 +60,8 @@ BrushedAluminium {
 
 > **File location**: "WEBOTS\_HOME/projects/appearances/protos/BrushedAluminium.proto"
 
-> **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
-[More information.](https://cyberbotics.com/webots_assets_license)
+> **License**: Apache License 2.0
+[More information.](http://www.apache.org/licenses/LICENSE-2.0)
 
 ### BrushedAluminium Field Summary
 
@@ -96,8 +96,8 @@ CarpetFibers {
 
 > **File location**: "WEBOTS\_HOME/projects/appearances/protos/CarpetFibers.proto"
 
-> **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
-[More information.](https://cyberbotics.com/webots_assets_license)
+> **License**: Apache License 2.0
+[More information.](http://www.apache.org/licenses/LICENSE-2.0)
 
 ### CarpetFibers Field Summary
 
@@ -131,8 +131,8 @@ ChequeredParquetry {
 
 > **File location**: "WEBOTS\_HOME/projects/appearances/protos/ChequeredParquetry.proto"
 
-> **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
-[More information.](https://cyberbotics.com/webots_assets_license)
+> **License**: Apache License 2.0
+[More information.](http://www.apache.org/licenses/LICENSE-2.0)
 
 ### ChequeredParquetry Field Summary
 
@@ -165,8 +165,8 @@ GlossyCarPaint {
 
 > **File location**: "WEBOTS\_HOME/projects/appearances/protos/GlossyCarPaint.proto"
 
-> **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
-[More information.](https://cyberbotics.com/webots_assets_license)
+> **License**: Apache License 2.0
+[More information.](http://www.apache.org/licenses/LICENSE-2.0)
 
 ### GlossyCarPaint Field Summary
 
@@ -201,8 +201,8 @@ MatteCarPaint {
 
 > **File location**: "WEBOTS\_HOME/projects/appearances/protos/MatteCarPaint.proto"
 
-> **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
-[More information.](https://cyberbotics.com/webots_assets_license)
+> **License**: Apache License 2.0
+[More information.](http://www.apache.org/licenses/LICENSE-2.0)
 
 ### MatteCarPaint Field Summary
 
@@ -236,8 +236,8 @@ MetalPipePaint {
 
 > **File location**: "WEBOTS\_HOME/projects/appearances/protos/MetalPipePaint.proto"
 
-> **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
-[More information.](https://cyberbotics.com/webots_assets_license)
+> **License**: Apache License 2.0
+[More information.](http://www.apache.org/licenses/LICENSE-2.0)
 
 ### MetalPipePaint Field Summary
 
@@ -270,8 +270,8 @@ OldSteel {
 
 > **File location**: "WEBOTS\_HOME/projects/appearances/protos/OldSteel.proto"
 
-> **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
-[More information.](https://cyberbotics.com/webots_assets_license)
+> **License**: Apache License 2.0
+[More information.](http://www.apache.org/licenses/LICENSE-2.0)
 
 ### OldSteel Field Summary
 
@@ -306,8 +306,8 @@ PaintedWood {
 
 > **File location**: "WEBOTS\_HOME/projects/appearances/protos/PaintedWood.proto"
 
-> **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
-[More information.](https://cyberbotics.com/webots_assets_license)
+> **License**: Apache License 2.0
+[More information.](http://www.apache.org/licenses/LICENSE-2.0)
 
 ### PaintedWood Field Summary
 
@@ -342,8 +342,8 @@ Parquetry {
 
 > **File location**: "WEBOTS\_HOME/projects/appearances/protos/Parquetry.proto"
 
-> **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
-[More information.](https://cyberbotics.com/webots_assets_license)
+> **License**: Apache License 2.0
+[More information.](http://www.apache.org/licenses/LICENSE-2.0)
 
 ### Parquetry Field Summary
 
@@ -377,8 +377,8 @@ RedBricks {
 
 > **File location**: "WEBOTS\_HOME/projects/appearances/protos/RedBricks.proto"
 
-> **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
-[More information.](https://cyberbotics.com/webots_assets_license)
+> **License**: Apache License 2.0
+[More information.](http://www.apache.org/licenses/LICENSE-2.0)
 
 ### RedBricks Field Summary
 
@@ -411,8 +411,8 @@ RoughConcrete {
 
 > **File location**: "WEBOTS\_HOME/projects/appearances/protos/RoughConcrete.proto"
 
-> **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
-[More information.](https://cyberbotics.com/webots_assets_license)
+> **License**: Apache License 2.0
+[More information.](http://www.apache.org/licenses/LICENSE-2.0)
 
 ### RoughConcrete Field Summary
 
@@ -447,8 +447,8 @@ RoughOak {
 
 > **File location**: "WEBOTS\_HOME/projects/appearances/protos/RoughOak.proto"
 
-> **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
-[More information.](https://cyberbotics.com/webots_assets_license)
+> **License**: Apache License 2.0
+[More information.](http://www.apache.org/licenses/LICENSE-2.0)
 
 ### RoughOak Field Summary
 
@@ -483,8 +483,8 @@ RoughPine {
 
 > **File location**: "WEBOTS\_HOME/projects/appearances/protos/RoughPine.proto"
 
-> **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
-[More information.](https://cyberbotics.com/webots_assets_license)
+> **License**: Apache License 2.0
+[More information.](http://www.apache.org/licenses/LICENSE-2.0)
 
 ### RoughPine Field Summary
 
@@ -519,8 +519,8 @@ Roughcast {
 
 > **File location**: "WEBOTS\_HOME/projects/appearances/protos/Roughcast.proto"
 
-> **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
-[More information.](https://cyberbotics.com/webots_assets_license)
+> **License**: Apache License 2.0
+[More information.](http://www.apache.org/licenses/LICENSE-2.0)
 
 ### Roughcast Field Summary
 
@@ -555,8 +555,8 @@ SandyGround {
 
 > **File location**: "WEBOTS\_HOME/projects/appearances/protos/SandyGround.proto"
 
-> **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
-[More information.](https://cyberbotics.com/webots_assets_license)
+> **License**: Apache License 2.0
+[More information.](http://www.apache.org/licenses/LICENSE-2.0)
 
 ### SandyGround Field Summary
 
@@ -591,8 +591,8 @@ ShinyLeather {
 
 > **File location**: "WEBOTS\_HOME/projects/appearances/protos/ShinyLeather.proto"
 
-> **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
-[More information.](https://cyberbotics.com/webots_assets_license)
+> **License**: Apache License 2.0
+[More information.](http://www.apache.org/licenses/LICENSE-2.0)
 
 ### ShinyLeather Field Summary
 
@@ -627,8 +627,8 @@ StonePavement {
 
 > **File location**: "WEBOTS\_HOME/projects/appearances/protos/StonePavement.proto"
 
-> **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
-[More information.](https://cyberbotics.com/webots_assets_license)
+> **License**: Apache License 2.0
+[More information.](http://www.apache.org/licenses/LICENSE-2.0)
 
 ### StonePavement Field Summary
 
@@ -663,8 +663,8 @@ ThreadMetalPlate {
 
 > **File location**: "WEBOTS\_HOME/projects/appearances/protos/ThreadMetalPlate.proto"
 
-> **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
-[More information.](https://cyberbotics.com/webots_assets_license)
+> **License**: Apache License 2.0
+[More information.](http://www.apache.org/licenses/LICENSE-2.0)
 
 ### ThreadMetalPlate Field Summary
 
@@ -699,8 +699,8 @@ VarnishedPine {
 
 > **File location**: "WEBOTS\_HOME/projects/appearances/protos/VarnishedPine.proto"
 
-> **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
-[More information.](https://cyberbotics.com/webots_assets_license)
+> **License**: Apache License 2.0
+[More information.](http://www.apache.org/licenses/LICENSE-2.0)
 
 ### VarnishedPine Field Summary
 
@@ -711,4 +711,3 @@ VarnishedPine {
 - `environmentMap`: Defines an optional `Cubemap` node overriding the skybox for this object.
 
 - `IBLStrength`: Defines the strength of ambient lighting from the Cubemap node.
-

--- a/projects/appearances/protos/Asphalt.proto
+++ b/projects/appearances/protos/Asphalt.proto
@@ -1,6 +1,6 @@
 #VRML_SIM R2019a utf8
 # license: Apache License 2.0
-# license url: https://cyberbotics.com/webots_assets_license
+# license url: http://www.apache.org/licenses/LICENSE-2.0
 # An asphalt material. The color can be overridden using the `colorOverride` field. Useful with the `Road` PROTO.
 
 PROTO Asphalt [

--- a/projects/appearances/protos/Asphalt.proto
+++ b/projects/appearances/protos/Asphalt.proto
@@ -1,5 +1,5 @@
 #VRML_SIM R2019a utf8
-# license: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
+# license: Apache License 2.0
 # license url: https://cyberbotics.com/webots_assets_license
 # An asphalt material. The color can be overridden using the `colorOverride` field. Useful with the `Road` PROTO.
 

--- a/projects/appearances/protos/BrushedAluminium.proto
+++ b/projects/appearances/protos/BrushedAluminium.proto
@@ -1,6 +1,6 @@
 #VRML_SIM R2019a utf8
 # license: Apache License 2.0
-# license url: https://cyberbotics.com/webots_assets_license
+# license url: http://www.apache.org/licenses/LICENSE-2.0
 # A brushed aluminum material.
 
 PROTO BrushedAluminium [

--- a/projects/appearances/protos/BrushedAluminium.proto
+++ b/projects/appearances/protos/BrushedAluminium.proto
@@ -1,5 +1,5 @@
 #VRML_SIM R2019a utf8
-# license: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
+# license: Apache License 2.0
 # license url: https://cyberbotics.com/webots_assets_license
 # A brushed aluminum material.
 

--- a/projects/appearances/protos/CarpetFibers.proto
+++ b/projects/appearances/protos/CarpetFibers.proto
@@ -1,6 +1,6 @@
 #VRML_SIM R2019a utf8
 # license: Apache License 2.0
-# license url: https://cyberbotics.com/webots_assets_license
+# license url: http://www.apache.org/licenses/LICENSE-2.0
 # A woolen carpet material. Useful with the `Floor` PROTO.
 
 PROTO CarpetFibers [

--- a/projects/appearances/protos/CarpetFibers.proto
+++ b/projects/appearances/protos/CarpetFibers.proto
@@ -1,5 +1,5 @@
 #VRML_SIM R2019a utf8
-# license: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
+# license: Apache License 2.0
 # license url: https://cyberbotics.com/webots_assets_license
 # A woolen carpet material. Useful with the `Floor` PROTO.
 

--- a/projects/appearances/protos/ChequeredParquetry.proto
+++ b/projects/appearances/protos/ChequeredParquetry.proto
@@ -1,5 +1,5 @@
 #VRML_SIM R2019a utf8
-# license: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
+# license: Apache License 2.0
 # license url: https://cyberbotics.com/webots_assets_license
 # A wooden material in a chequered pattern covered with a layer of varnish. Useful with the `Floor` PROTO.
 

--- a/projects/appearances/protos/ChequeredParquetry.proto
+++ b/projects/appearances/protos/ChequeredParquetry.proto
@@ -1,6 +1,6 @@
 #VRML_SIM R2019a utf8
 # license: Apache License 2.0
-# license url: https://cyberbotics.com/webots_assets_license
+# license url: http://www.apache.org/licenses/LICENSE-2.0
 # A wooden material in a chequered pattern covered with a layer of varnish. Useful with the `Floor` PROTO.
 
 PROTO ChequeredParquetry [

--- a/projects/appearances/protos/GlossyCarPaint.proto
+++ b/projects/appearances/protos/GlossyCarPaint.proto
@@ -1,6 +1,6 @@
 #VRML_SIM R2019a utf8
 # license: Apache License 2.0
-# license url: https://cyberbotics.com/webots_assets_license
+# license url: http://www.apache.org/licenses/LICENSE-2.0
 # A glossy car paint material. The color can be selected in the `baseColor` field. Useful with any of the vehicle PROTOs.
 
 PROTO GlossyCarPaint [

--- a/projects/appearances/protos/GlossyCarPaint.proto
+++ b/projects/appearances/protos/GlossyCarPaint.proto
@@ -1,5 +1,5 @@
 #VRML_SIM R2019a utf8
-# license: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
+# license: Apache License 2.0
 # license url: https://cyberbotics.com/webots_assets_license
 # A glossy car paint material. The color can be selected in the `baseColor` field. Useful with any of the vehicle PROTOs.
 

--- a/projects/appearances/protos/MatteCarPaint.proto
+++ b/projects/appearances/protos/MatteCarPaint.proto
@@ -1,5 +1,5 @@
 #VRML_SIM R2019a utf8
-# license: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
+# license: Apache License 2.0
 # license url: https://cyberbotics.com/webots_assets_license
 # A matte car paint material. The color can be selected in the `baseColor` field. Useful with any of the vehicle PROTOs.
 

--- a/projects/appearances/protos/MatteCarPaint.proto
+++ b/projects/appearances/protos/MatteCarPaint.proto
@@ -1,6 +1,6 @@
 #VRML_SIM R2019a utf8
 # license: Apache License 2.0
-# license url: https://cyberbotics.com/webots_assets_license
+# license url: http://www.apache.org/licenses/LICENSE-2.0
 # A matte car paint material. The color can be selected in the `baseColor` field. Useful with any of the vehicle PROTOs.
 
 PROTO MatteCarPaint [

--- a/projects/appearances/protos/MetalPipePaint.proto
+++ b/projects/appearances/protos/MetalPipePaint.proto
@@ -1,5 +1,5 @@
 #VRML_SIM R2019a utf8
-# license: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
+# license: Apache License 2.0
 # license url: https://cyberbotics.com/webots_assets_license
 # A worn paint layer on a metal surface. Useful with the `PipeSection` PROTO or any painted industrial surfaces.
 

--- a/projects/appearances/protos/MetalPipePaint.proto
+++ b/projects/appearances/protos/MetalPipePaint.proto
@@ -1,6 +1,6 @@
 #VRML_SIM R2019a utf8
 # license: Apache License 2.0
-# license url: https://cyberbotics.com/webots_assets_license
+# license url: http://www.apache.org/licenses/LICENSE-2.0
 # A worn paint layer on a metal surface. Useful with the `PipeSection` PROTO or any painted industrial surfaces.
 
 PROTO MetalPipePaint [

--- a/projects/appearances/protos/OldSteel.proto
+++ b/projects/appearances/protos/OldSteel.proto
@@ -1,5 +1,5 @@
 #VRML_SIM R2019a utf8
-# license: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
+# license: Apache License 2.0
 # license url: https://cyberbotics.com/webots_assets_license
 # An old battered steel material.
 

--- a/projects/appearances/protos/OldSteel.proto
+++ b/projects/appearances/protos/OldSteel.proto
@@ -1,6 +1,6 @@
 #VRML_SIM R2019a utf8
 # license: Apache License 2.0
-# license url: https://cyberbotics.com/webots_assets_license
+# license url: http://www.apache.org/licenses/LICENSE-2.0
 # An old battered steel material.
 
 PROTO OldSteel [

--- a/projects/appearances/protos/PaintedWood.proto
+++ b/projects/appearances/protos/PaintedWood.proto
@@ -1,6 +1,6 @@
 #VRML_SIM R2019a utf8
 # license: Apache License 2.0
-# license url: https://cyberbotics.com/webots_assets_license
+# license url: http://www.apache.org/licenses/LICENSE-2.0
 # A painted wood material. The color can be overridden using the `colorOverride` field.
 
 PROTO PaintedWood [

--- a/projects/appearances/protos/PaintedWood.proto
+++ b/projects/appearances/protos/PaintedWood.proto
@@ -1,5 +1,5 @@
 #VRML_SIM R2019a utf8
-# license: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
+# license: Apache License 2.0
 # license url: https://cyberbotics.com/webots_assets_license
 # A painted wood material. The color can be overridden using the `colorOverride` field.
 

--- a/projects/appearances/protos/Parquetry.proto
+++ b/projects/appearances/protos/Parquetry.proto
@@ -1,6 +1,6 @@
 #VRML_SIM R2019a utf8
 # license: Apache License 2.0
-# license url: https://cyberbotics.com/webots_assets_license
+# license url: http://www.apache.org/licenses/LICENSE-2.0
 # A wooden material in a tesselated block pattern covered with a layer of varnish. Useful with the `Floor` PROTO.
 
 PROTO Parquetry [

--- a/projects/appearances/protos/Parquetry.proto
+++ b/projects/appearances/protos/Parquetry.proto
@@ -1,5 +1,5 @@
 #VRML_SIM R2019a utf8
-# license: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
+# license: Apache License 2.0
 # license url: https://cyberbotics.com/webots_assets_license
 # A wooden material in a tesselated block pattern covered with a layer of varnish. Useful with the `Floor` PROTO.
 

--- a/projects/appearances/protos/RedBricks.proto
+++ b/projects/appearances/protos/RedBricks.proto
@@ -1,6 +1,6 @@
 #VRML_SIM R2019a utf8
 # license: Apache License 2.0
-# license url: https://cyberbotics.com/webots_assets_license
+# license url: http://www.apache.org/licenses/LICENSE-2.0
 # A tiled brick material. Useful with the `Wall` PROTO.
 
 PROTO RedBricks [

--- a/projects/appearances/protos/RedBricks.proto
+++ b/projects/appearances/protos/RedBricks.proto
@@ -1,5 +1,5 @@
 #VRML_SIM R2019a utf8
-# license: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
+# license: Apache License 2.0
 # license url: https://cyberbotics.com/webots_assets_license
 # A tiled brick material. Useful with the `Wall` PROTO.
 

--- a/projects/appearances/protos/RoughConcrete.proto
+++ b/projects/appearances/protos/RoughConcrete.proto
@@ -1,5 +1,5 @@
 #VRML_SIM R2019a utf8
-# license: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
+# license: Apache License 2.0
 # license url: https://cyberbotics.com/webots_assets_license
 # A rough concrete material. The color can be overridden using the `colorOverride` field.
 

--- a/projects/appearances/protos/RoughConcrete.proto
+++ b/projects/appearances/protos/RoughConcrete.proto
@@ -1,6 +1,6 @@
 #VRML_SIM R2019a utf8
 # license: Apache License 2.0
-# license url: https://cyberbotics.com/webots_assets_license
+# license url: http://www.apache.org/licenses/LICENSE-2.0
 # A rough concrete material. The color can be overridden using the `colorOverride` field.
 
 PROTO RoughConcrete [

--- a/projects/appearances/protos/RoughOak.proto
+++ b/projects/appearances/protos/RoughOak.proto
@@ -1,5 +1,5 @@
 #VRML_SIM R2019a utf8
-# license: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
+# license: Apache License 2.0
 # license url: https://cyberbotics.com/webots_assets_license
 # A rough oak material. The color can be overridden using the `colorOverride` field.
 

--- a/projects/appearances/protos/RoughOak.proto
+++ b/projects/appearances/protos/RoughOak.proto
@@ -1,6 +1,6 @@
 #VRML_SIM R2019a utf8
 # license: Apache License 2.0
-# license url: https://cyberbotics.com/webots_assets_license
+# license url: http://www.apache.org/licenses/LICENSE-2.0
 # A rough oak material. The color can be overridden using the `colorOverride` field.
 
 PROTO RoughOak [

--- a/projects/appearances/protos/RoughPine.proto
+++ b/projects/appearances/protos/RoughPine.proto
@@ -1,6 +1,6 @@
 #VRML_SIM R2019a utf8
 # license: Apache License 2.0
-# license url: https://cyberbotics.com/webots_assets_license
+# license url: http://www.apache.org/licenses/LICENSE-2.0
 # A pine wood material. The color can be overridden using the `colorOverride` field.
 
 PROTO RoughPine [

--- a/projects/appearances/protos/RoughPine.proto
+++ b/projects/appearances/protos/RoughPine.proto
@@ -1,5 +1,5 @@
 #VRML_SIM R2019a utf8
-# license: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
+# license: Apache License 2.0
 # license url: https://cyberbotics.com/webots_assets_license
 # A pine wood material. The color can be overridden using the `colorOverride` field.
 

--- a/projects/appearances/protos/Roughcast.proto
+++ b/projects/appearances/protos/Roughcast.proto
@@ -1,5 +1,5 @@
 #VRML_SIM R2019a utf8
-# license: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
+# license: Apache License 2.0
 # license url: https://cyberbotics.com/webots_assets_license
 # A rough plaster material. Useful with the `Wall` PROTO.
 

--- a/projects/appearances/protos/Roughcast.proto
+++ b/projects/appearances/protos/Roughcast.proto
@@ -1,6 +1,6 @@
 #VRML_SIM R2019a utf8
 # license: Apache License 2.0
-# license url: https://cyberbotics.com/webots_assets_license
+# license url: http://www.apache.org/licenses/LICENSE-2.0
 # A rough plaster material. Useful with the `Wall` PROTO.
 
 PROTO Roughcast [

--- a/projects/appearances/protos/SandyGround.proto
+++ b/projects/appearances/protos/SandyGround.proto
@@ -1,5 +1,5 @@
 #VRML_SIM R2019a utf8
-# license: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
+# license: Apache License 2.0
 # license url: https://cyberbotics.com/webots_assets_license
 # A sandy ground material. The color can be selected using the `colorOverride` field. Useful with the UnevenTerrain PROTO.
 

--- a/projects/appearances/protos/SandyGround.proto
+++ b/projects/appearances/protos/SandyGround.proto
@@ -1,6 +1,6 @@
 #VRML_SIM R2019a utf8
 # license: Apache License 2.0
-# license url: https://cyberbotics.com/webots_assets_license
+# license url: http://www.apache.org/licenses/LICENSE-2.0
 # A sandy ground material. The color can be selected using the `colorOverride` field. Useful with the UnevenTerrain PROTO.
 
 PROTO SandyGround [

--- a/projects/appearances/protos/ShinyLeather.proto
+++ b/projects/appearances/protos/ShinyLeather.proto
@@ -1,6 +1,6 @@
 #VRML_SIM R2019a utf8
 # license: Apache License 2.0
-# license url: https://cyberbotics.com/webots_assets_license
+# license url: http://www.apache.org/licenses/LICENSE-2.0
 # A shiny leather material. The color can be selected using the `colorOverride` field. Useful with any of the vehicle PROTOs.
 
 PROTO ShinyLeather [

--- a/projects/appearances/protos/ShinyLeather.proto
+++ b/projects/appearances/protos/ShinyLeather.proto
@@ -1,5 +1,5 @@
 #VRML_SIM R2019a utf8
-# license: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
+# license: Apache License 2.0
 # license url: https://cyberbotics.com/webots_assets_license
 # A shiny leather material. The color can be selected using the `colorOverride` field. Useful with any of the vehicle PROTOs.
 

--- a/projects/appearances/protos/StonePavement.proto
+++ b/projects/appearances/protos/StonePavement.proto
@@ -1,5 +1,5 @@
 #VRML_SIM R2019a utf8
-# license: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
+# license: Apache License 2.0
 # license url: https://cyberbotics.com/webots_assets_license
 # A stone pavement material. The color can be overridden using the `colorOverride` field. Useful with the `Road` PROTO.
 

--- a/projects/appearances/protos/StonePavement.proto
+++ b/projects/appearances/protos/StonePavement.proto
@@ -1,6 +1,6 @@
 #VRML_SIM R2019a utf8
 # license: Apache License 2.0
-# license url: https://cyberbotics.com/webots_assets_license
+# license url: http://www.apache.org/licenses/LICENSE-2.0
 # A stone pavement material. The color can be overridden using the `colorOverride` field. Useful with the `Road` PROTO.
 
 PROTO StonePavement [

--- a/projects/appearances/protos/ThreadMetalPlate.proto
+++ b/projects/appearances/protos/ThreadMetalPlate.proto
@@ -1,5 +1,5 @@
 #VRML_SIM R2019a utf8
-# license: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
+# license: Apache License 2.0
 # license url: https://cyberbotics.com/webots_assets_license
 # A worn paint layer on a metal surface. Useful with the `PipeSection` PROTO or any painted industrial surfaces.
 

--- a/projects/appearances/protos/ThreadMetalPlate.proto
+++ b/projects/appearances/protos/ThreadMetalPlate.proto
@@ -1,6 +1,6 @@
 #VRML_SIM R2019a utf8
 # license: Apache License 2.0
-# license url: https://cyberbotics.com/webots_assets_license
+# license url: http://www.apache.org/licenses/LICENSE-2.0
 # A worn paint layer on a metal surface. Useful with the `PipeSection` PROTO or any painted industrial surfaces.
 
 PROTO ThreadMetalPlate [

--- a/projects/appearances/protos/VarnishedPine.proto
+++ b/projects/appearances/protos/VarnishedPine.proto
@@ -1,6 +1,6 @@
 #VRML_SIM R2019a utf8
 # license: Apache License 2.0
-# license url: https://cyberbotics.com/webots_assets_license
+# license url: http://www.apache.org/licenses/LICENSE-2.0
 # A pine wood material covered with a layer of varnish. The color can be overridden using the `colorOverride` field.
 
 PROTO VarnishedPine [

--- a/projects/appearances/protos/VarnishedPine.proto
+++ b/projects/appearances/protos/VarnishedPine.proto
@@ -1,5 +1,5 @@
 #VRML_SIM R2019a utf8
-# license: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
+# license: Apache License 2.0
 # license url: https://cyberbotics.com/webots_assets_license
 # A pine wood material covered with a layer of varnish. The color can be overridden using the `colorOverride` field.
 


### PR DESCRIPTION
We decided to release all the appearances PROTO with the Apache 2.0 license to make sure that their use do not 'contaminate' the user PROTOs.