### PR TITLE
Fix E-puck Light Sensors Calibration.

### DIFF
--- a/change_logs/ChangeLog.html
+++ b/change_logs/ChangeLog.html
@@ -37,6 +37,7 @@ Released on February 14th, 2019
 <li>Fixed TextureTransform field changes applied only at revert.</li>
 <li>Fixed crash while recording a movie with some low-end GPU.</li>
 <li>Fixed MATLAB controllers causing MATLAB crashes at startup on Windows.</li>
+<li>Fixed e-puck light sensors calibration in worlds using PBR.</li>
 </ul>
 </ul>
 

--- a/projects/robots/gctronic/e-puck/protos/E-puck.proto
+++ b/projects/robots/gctronic/e-puck/protos/E-puck.proto
@@ -540,7 +540,7 @@ Robot {
       rotation 0 1 0 1.27
       name "ls0"
       lookupTable [
-        0 4095 0.01 0.2 0 0.01
+        1 4095 0.01 2 0 0.01
       ]
     }
     DEF EPUCK_LS1 LightSensor {
@@ -548,14 +548,14 @@ Robot {
       rotation 0 1 0 0.77
       name "ls1"
       lookupTable [
-        0 4095 0.01 0.2 0 0.01
+        1 4095 0.01 2 0 0.01
       ]
     }
     DEF EPUCK_LS2 LightSensor {
       translation 0.031 0.0329 0
       name "ls2"
       lookupTable [
-        0 4095 0.01 0.2 0 0.01
+        1 4095 0.01 2 0 0.01
       ]
     }
     DEF EPUCK_LS3 LightSensor {
@@ -563,7 +563,7 @@ Robot {
       rotation 0 1 0 5.21
       name "ls3"
       lookupTable [
-        0 4095 0.01 0.2 0 0.01
+        1 4095 0.01 2 0 0.01
       ]
     }
     DEF EPUCK_LS4 LightSensor {
@@ -571,7 +571,7 @@ Robot {
       rotation 0 1 0 4.21
       name "ls4"
       lookupTable [
-        0 4095 0.01 0.2 0 0.01
+        1 4095 0.01 2 0 0.01
       ]
     }
     DEF EPUCK_LS5 LightSensor {
@@ -579,7 +579,7 @@ Robot {
       rotation 0 1 0 3.14159
       name "ls5"
       lookupTable [
-        0 4095 0.01 0.2 0 0.01
+        1 4095 0.01 2 0 0.01
       ]
     }
     DEF EPUCK_LS6 LightSensor {
@@ -587,7 +587,7 @@ Robot {
       rotation 0 1 0 2.37
       name "ls6"
       lookupTable [
-        0 4095 0.01 0.2 0 0.01
+        1 4095 0.01 2 0 0.01
       ]
     }
     DEF EPUCK_LS7 LightSensor {
@@ -595,7 +595,7 @@ Robot {
       rotation 0 1 0 1.87
       name "ls7"
       lookupTable [
-        0 4095 0.01 0.2 0 0.01
+        1 4095 0.01 2 0 0.01
       ]
     }
     DEF EPUCK_CAMERA Camera {


### PR DESCRIPTION
Since the introduction of PBR we did set the ambient intensity of the default TexturedBackground to 1.0, so that non-PBR objects are ambient illuminated in a similar way than the PBR ones are by the background.
Since the introduction of HDR the intensity range of light has increased.

These two reasons imply that the calibration of the e-puck light sensors had to be updated.

I checked all the e-puck worlds and now the behavior of the light sensors are correct, the sensors facing the light return 0, the ones on the opposite side return ~4095 and the ones facing not exactly the light return an intermediate value.