### PR TITLE
Add \f examples printf in devices controllers

### DIFF
--- a/projects/samples/devices/controllers/battery/battery.c
+++ b/projects/samples/devices/controllers/battery/battery.c
@@ -48,7 +48,7 @@ int main() {
   wb_robot_battery_sensor_enable(TIME_STEP);
 
   while (wb_robot_step(TIME_STEP) != -1) {
-    printf("Battery sensor value: %.3f J\n", wb_robot_battery_sensor_get_value());
+    printf("\fBattery sensor value: %.3f J\n", wb_robot_battery_sensor_get_value());
     const double ds0_value = wb_distance_sensor_get_value(ds0);
     const double ds1_value = wb_distance_sensor_get_value(ds1);
 

--- a/projects/samples/devices/controllers/gyro/gyro.c
+++ b/projects/samples/devices/controllers/gyro/gyro.c
@@ -41,7 +41,7 @@ static void run_for_a_while() {
     if (wb_robot_step(TIME_STEP) == -1)
       exit(EXIT_SUCCESS);
     const double *vel = wb_gyro_get_values(gyro);
-    printf("rotation axes: [ x y z ] = [ %+.2f %+.2f %+.2f ]\n", vel[0], vel[1], vel[2]);
+    printf("\frotation axes: [ x y z ] = [ %+.2f %+.2f %+.2f ]\n", vel[0], vel[1], vel[2]);
   }
 }
 

--- a/projects/samples/devices/controllers/motor/motor.c
+++ b/projects/samples/devices/controllers/motor/motor.c
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
       target += M_PI_4;
       counter = 0;
     }
-    printf("Force feedback = %g\n", wb_motor_get_torque_feedback(motor));
+    printf("\fForce feedback = %g\n", wb_motor_get_torque_feedback(motor));
     printf("Battery level  = %g\n", wb_robot_battery_sensor_get_value());
   };
   wb_robot_cleanup();

--- a/projects/samples/devices/controllers/position_sensor/position_sensor.c
+++ b/projects/samples/devices/controllers/position_sensor/position_sensor.c
@@ -76,7 +76,7 @@ int main(int argc, char **argv) {
 
     wb_motor_set_velocity(left_motor, -speed);
     wb_motor_set_velocity(right_motor, -speed);
-    printf("Position: %+f -> control force: %+f\n", position, speed);
+    printf("\fPosition: %+f -> control force: %+f\n", position, speed);
 
     previous_position = position;
   };

--- a/projects/samples/devices/controllers/radar/radar.c
+++ b/projects/samples/devices/controllers/radar/radar.c
@@ -64,7 +64,7 @@ int main() {
     if (radar) {
       int targets_number = wb_radar_get_number_of_targets(radar);
       const WbRadarTarget *targets = wb_radar_get_targets(radar);
-      printf("%s see %d targets.\n", wb_robot_get_name(), targets_number);
+      printf("\f%s see %d targets.\n", wb_robot_get_name(), targets_number);
       for (i = 0; i < targets_number; ++i)
         printf("---target %d: distance=%lf azimuth=%lf\n", i + 1, targets[i].distance, targets[i].azimuth);
     }

--- a/projects/samples/devices/controllers/receiver_noise/receiver_noise.c
+++ b/projects/samples/devices/controllers/receiver_noise/receiver_noise.c
@@ -64,12 +64,6 @@ int main() {
     robot_type = RECEIVER;
     communication = wb_robot_get_device("receiver");
     wb_receiver_enable(communication, TIME_STEP);
-
-    printf("Example usage of signalStrengthNoise and directionNoise in a Receiver.\n");
-    printf("The real position of the emitter robot obtained from a noise-free GPS is\n");
-    printf("compared to the position computed from the direction and signal strenght\n");
-    printf("information. Changing the 'signalStrengthNoise' or 'directionNoise' of the\n");
-    printf("Receiver should affect the results.\n\n");
   } else {
     printf("Unrecognized robot name '%s'. Exiting...\n", wb_robot_get_name());
     wb_robot_cleanup();
@@ -101,7 +95,7 @@ int main() {
       wb_emitter_send(communication, message, strlen(message) + 1);
       const double *gpsPosition = wb_gps_get_values(gps);
       /* print real position measured from the GPS */
-      printf("GPS position:     time = %.3lf   X = %.3lf Z = %.3lf\n\n", wb_robot_get_time(), gpsPosition[0], gpsPosition[2]);
+      printf("GPS position:     time = %.3lf   X = %.3lf Z = %.3lf\n", wb_robot_get_time(), gpsPosition[0], gpsPosition[2]);
 
     } else {
       /* is there at least one packet in the receiver's queue ? */
@@ -110,7 +104,7 @@ int main() {
         double signalStrength = wb_receiver_get_signal_strength(communication);
         const double *direction = wb_receiver_get_emitter_direction(communication);
         double dist = 1 / sqrt(signalStrength);
-        printf("Emitter position: time = %.3lf   X = %.3lf Z = %.3lf\n", wb_robot_get_time(), direction[0] * dist,
+        printf("\fEmitter position: time = %.3lf   X = %.3lf Z = %.3lf\n", wb_robot_get_time(), direction[0] * dist,
                direction[2] * dist);
 
         wb_receiver_next_packet(communication);

--- a/projects/samples/devices/controllers/spherical_camera/spherical_camera.c
+++ b/projects/samples/devices/controllers/spherical_camera/spherical_camera.c
@@ -122,11 +122,11 @@ int main(int argc, char **argv) {
     }
 
     // print results
+    printf("\f");
     for (i = 0; i < 3; i++)
       printf("last %s blob seen at (%d,%d) with an angle of %f\n", (i == GREEN) ? "Green" : (i == RED) ? "Red" : "Blue",
              color_index[i][X], color_index[i][Y],
              coord2D_to_angle((double)(color_index[i][X] + width / 2), (double)(color_index[i][Y] + height / 2)));
-    printf("\n");
 
     // set actuators
     wb_motor_set_velocity(left_motor, 3.0 + speed[LEFT]);

--- a/projects/samples/devices/worlds/receiver_noise.wbt
+++ b/projects/samples/devices/worlds/receiver_noise.wbt
@@ -1,7 +1,10 @@
 #VRML_SIM R2019a utf8
 WorldInfo {
   info [
-    "Illustartion of signalStrengthNoise and directionNoise of the Receiver."
+    "Demonstration of the signalStrengthNoise and directionNoise of the Receiver node."
+    ""
+    "The real position of the emitter robot obtained from a noise-free GPS is compared to the position computed from the direction and signal strenght information."
+    "Changing the 'signalStrengthNoise' or 'directionNoise' of the Receiver node should affect the results."
   ]
   title "Receiver Noise"
 }


### PR DESCRIPTION
This PR adds examples of using `printf("\f");` to clear the console and have a better, more readable output in the Webots console.