### PR TITLE
Fix disabled Fog when visibilityRange is 0

### DIFF
--- a/change_logs/ChangeLog.html
+++ b/change_logs/ChangeLog.html
@@ -9,6 +9,20 @@
 
 <h1>Webots change log</h1>
 
+
+<h2>Webots R2019a revision 2</h2>
+Released on xx xxth, 2019
+
+<ul>
+<li><b>Enhancements</b></li>
+<ul>
+</ul>
+<li><b>Bug fixes</b></li>
+<ul>
+<li>Fixed Fog node not disabled when visibility range is 0.</li>
+</ul>
+</ul>
+
 <h2>Webots R2019a revision 1</h2>
 Released on February 14th, 2019
 

--- a/src/webots/nodes/WbFog.cpp
+++ b/src/webots/nodes/WbFog.cpp
@@ -142,13 +142,15 @@ void WbFog::updateVisibilityRange() {
 void WbFog::applyChangesToWren() {
   assert(isFirstInstance());
 
+  WrSceneFogType fogType = mWrenFogType;
   float density = 0.0f;
   if (mVisibilityRange->value() > 0.0)
     density = 1.0 / mVisibilityRange->value();
-
+  else
+    fogType = WR_SCENE_FOG_TYPE_NONE;
   const float color[] = {static_cast<float>(mColor->red()), static_cast<float>(mColor->green()),
                          static_cast<float>(mColor->blue())};
 
-  wr_scene_set_fog(wr_scene_get_instance(), mWrenFogType, WR_SCENE_FOG_DEPTH_TYPE_POINT, color, density, 0.0f,
+  wr_scene_set_fog(wr_scene_get_instance(), fogType, WR_SCENE_FOG_DEPTH_TYPE_POINT, color, density, 0.0f,
                    mVisibilityRange->value());
 }


### PR DESCRIPTION
Fix #307: as stated in the docs if the `Fog.visibilityRange` is 0, then the Fog node is disabled.