### PR TITLE
Remove unused functions

### DIFF
--- a/src/webots/nodes/WbAppearance.cpp
+++ b/src/webots/nodes/WbAppearance.cpp
@@ -158,11 +158,6 @@ WrMaterial *WbAppearance::modifyWrenMaterial(WrMaterial *wrenMaterial) {
   return wrenMaterial;
 }
 
-bool WbAppearance::isTransparent() {
-  return (material() && material()->transparency() > 0.0) ||
-         (texture() && texture()->wrenTexture() && wr_texture_is_translucent(texture()->wrenTexture()));
-}
-
 bool WbAppearance::isTextureLoaded() const {
   return (texture() && texture()->wrenTexture());
 }

--- a/src/webots/nodes/WbAppearance.hpp
+++ b/src/webots/nodes/WbAppearance.hpp
@@ -64,7 +64,6 @@ private:
   WbAppearance &operator=(const WbAppearance &);  // non copyable
   WbNode *clone() const override { return new WbAppearance(*this); }
 
-  bool isTransparent();
   void init();
 
 private slots:

--- a/src/webots/nodes/WbImageTexture.cpp
+++ b/src/webots/nodes/WbImageTexture.cpp
@@ -305,12 +305,6 @@ void WbImageTexture::unsetBackgroundTexture() {
   emit changed();
 }
 
-bool WbImageTexture::isTransparent() const {
-  if (mWrenTexture)
-    return wr_texture_is_translucent(WR_TEXTURE(mWrenTexture));
-  return false;
-}
-
 int WbImageTexture::width() const {
   if (mWrenTexture)
     return wr_texture_get_width(WR_TEXTURE(mWrenTexture));

--- a/src/webots/nodes/WbImageTexture.hpp
+++ b/src/webots/nodes/WbImageTexture.hpp
@@ -51,7 +51,6 @@ public:
   // Texture features
   int width() const;
   int height() const;
-  bool isTransparent() const;
   int filtering() const;
 
   // external texture

--- a/src/webots/nodes/WbPbrAppearance.hpp
+++ b/src/webots/nodes/WbPbrAppearance.hpp
@@ -71,7 +71,6 @@ private:
   WbNode *clone() const override { return new WbPbrAppearance(*this); }
   void clearCubemap(WrMaterial *wrenMaterial);
 
-  bool isTransparent();
   void init();
 
   WbSFColor *mBaseColor;

--- a/src/webots/wren/WbWrenTextureOverlay.cpp
+++ b/src/webots/wren/WbWrenTextureOverlay.cpp
@@ -379,10 +379,6 @@ int WbWrenTextureOverlay::height() const {
   return wr_overlay_get_height(mWrenOverlay) * wr_viewport_get_height(wr_scene_get_viewport(wr_scene_get_instance()));
 }
 
-bool WbWrenTextureOverlay::isTransparent() const {
-  return (mTextureType == TEXTURE_TYPE_BGRA);
-}
-
 bool WbWrenTextureOverlay::isVisible() const {
   return (mWrenOverlay && wr_overlay_is_visible(mWrenOverlay));
 }

--- a/src/webots/wren/WbWrenTextureOverlay.hpp
+++ b/src/webots/wren/WbWrenTextureOverlay.hpp
@@ -107,9 +107,6 @@ private:
   int width() const;
   int height() const;
 
-  // Accessors for mWrenTexture
-  bool isTransparent() const;
-
   WrTexture2d *createIconTexture(QString filePath);
   void copyDataToTexture(void *data, TextureType type, int x, int y, int width, int height);
 


### PR DESCRIPTION
Remove unused functions: the information about appearance and texture transparency is only used by WREN and not by Webots.
Removing these unused functions helps understanding where the transparency is handled.