### PR TITLE
Fix AMD GPU memory reading

### DIFF
--- a/change_logs/ChangeLog.html
+++ b/change_logs/ChangeLog.html
@@ -20,6 +20,7 @@ Released on xx xxth, 2019
 <li><b>Bug fixes</b></li>
 <ul>
 <li>Fixed Fog node not disabled when visibility range is 0.</li>
+<li>Fixed reading of available GPU memory on some AMD graphics cards.</li>
 </ul>
 </ul>
 

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -1610,7 +1610,13 @@ void WbMainWindow::showOpenGlInfo() {
   info += tr("OpenGL vendor: ") + (const char *)gl.glGetString(GL_VENDOR) + "\n";
   info += tr("OpenGL renderer: ") + (const char *)gl.glGetString(GL_RENDERER) + "\n";
   info += tr("OpenGL version: ") + (const char *)gl.glGetString(GL_VERSION) + "\n";
-  info += tr("Available GPU memory: %1 bytes").arg(wr_gl_state_get_gpu_memory()) + "\n";
+  info += tr("Available GPU memory: ");
+  int gpu_memory = wr_gl_state_get_gpu_memory();
+  if (gpu_memory > 0)
+    info += tr("%1 bytes").arg(gpu_memory);
+  else
+    info += tr("N/A");
+  info += "\n";
   WbMessageBox::info(info, this, tr("OpenGL information"));
 }
 

--- a/src/wren/GlState.cpp
+++ b/src/wren/GlState.cpp
@@ -129,7 +129,7 @@ namespace wren {
         array[0] = -1;
         glGetIntegerv(GL_TEXTURE_FREE_MEMORY_ATI, array);
         cGpuMemory = array[0];
-        while (glGetError()) {  // skip any possible GL_INVALID_ENUM error
+        while (glGetError() != GL_NO_ERROR) {  // skip any possible GL_INVALID_ENUM error
         }
       }
       // setup uniform buffers

--- a/src/wren/GlState.cpp
+++ b/src/wren/GlState.cpp
@@ -731,14 +731,11 @@ namespace wren {
       return cUniformBuffers[buffer].get();
     }
 
-    bool checkError(int ignore) {
-      bool hasError = false;
+    void checkError(int ignore) {
       int error;
-
       do {
         error = glGetError();
         if (error != GL_NO_ERROR && error != ignore) {
-          hasError = true;
           std::cerr << "OpenGL error: ";
           switch (error) {
             case GL_INVALID_ENUM:
@@ -762,8 +759,6 @@ namespace wren {
           std::cerr << std::endl;
         }
       } while (error != GL_NO_ERROR);
-
-      return hasError;
     }
 
   }  // namespace glstate

--- a/src/wren/GlState.cpp
+++ b/src/wren/GlState.cpp
@@ -125,13 +125,11 @@ namespace wren {
       else {
         // Try to use GL_TEXTURE_FREE_MEMORY_ATI:
         // it seems to be working even if the corresponding GLAD_GL_ATI_meminfo is not available
-        GLint array[4];
+        int array[4];
         array[0] = -1;
-        checkError();  // display any previous error before possibly causing a GL_INVALID_ENUM error
         glGetIntegerv(GL_TEXTURE_FREE_MEMORY_ATI, array);
         cGpuMemory = array[0];
-        while (glGetError() != GL_NO_ERROR) {  // skip any possible GL_INVALID_ENUM error
-        }
+        checkError(GL_INVALID_ENUM);  // check errors skipping any possible GL_INVALID_ENUM error
       }
       // setup uniform buffers
       size_t count = GlslLayout::gUniformBufferNames.size();
@@ -733,13 +731,13 @@ namespace wren {
       return cUniformBuffers[buffer].get();
     }
 
-    bool checkError() {
+    bool checkError(int ignore) {
       bool hasError = false;
-      unsigned int error;
+      int error;
 
       do {
         error = glGetError();
-        if (error != GL_NO_ERROR) {
+        if (error != GL_NO_ERROR && error != ignore) {
           hasError = true;
           std::cerr << "OpenGL error: ";
           switch (error) {

--- a/src/wren/GlState.cpp
+++ b/src/wren/GlState.cpp
@@ -127,6 +127,7 @@ namespace wren {
         // it seems to be working even if the corresponding GLAD_GL_ATI_meminfo is not available
         GLint array[4];
         array[0] = -1;
+        checkError();  // display any previous error before possibly causing a GL_INVALID_ENUM error
         glGetIntegerv(GL_TEXTURE_FREE_MEMORY_ATI, array);
         cGpuMemory = array[0];
         while (glGetError() != GL_NO_ERROR) {  // skip any possible GL_INVALID_ENUM error

--- a/src/wren/GlState.cpp
+++ b/src/wren/GlState.cpp
@@ -120,15 +120,18 @@ namespace wren {
       cVersion = reinterpret_cast<const char *>(glGetString(GL_VERSION));
       cGlslVersion = reinterpret_cast<const char *>(glGetString(GL_SHADING_LANGUAGE_VERSION));
 
-      if (GLAD_GL_ATI_meminfo)
-        glGetIntegerv(GL_TEXTURE_FREE_MEMORY_ATI, &cGpuMemory);
-      else if (GLAD_GL_NVX_gpu_memory_info)
+      if (GLAD_GL_NVX_gpu_memory_info)
         glGetIntegerv(GL_GPU_MEMORY_INFO_TOTAL_AVAILABLE_MEMORY_NVX, &cGpuMemory);
-      else
-        DEBUG("GL_TEXTURE_FREE_MEMORY_ATI and GL_GPU_MEMORY_INFO_TOTAL_AVAILABLE_MEMORY_NVX extensions not supported by "
-              "hardware, impossible to detect GPU memory"
-              << std::endl);
-
+      else {
+        // Try to use GL_TEXTURE_FREE_MEMORY_ATI:
+        // it seems to be working even if the corresponding GLAD_GL_ATI_meminfo is not available
+        GLint array[4];
+        array[0] = -1;
+        glGetIntegerv(GL_TEXTURE_FREE_MEMORY_ATI, array);
+        cGpuMemory = array[0];
+        while (glGetError()) {  // skip any possible GL_INVALID_ENUM error
+        }
+      }
       // setup uniform buffers
       size_t count = GlslLayout::gUniformBufferNames.size();
       cUniformBuffers.reserve(count);

--- a/src/wren/GlState.hpp
+++ b/src/wren/GlState.hpp
@@ -128,8 +128,8 @@ namespace wren {
     unsigned int activeProgram();
     const UniformBuffer *uniformBuffer(WrGlslLayoutUniformBuffer buffer);
 
-    // Returns true and prints the error code(s) if OpenGL errors have ocurred since the last invocation
-    bool checkError(int ignore = 0);
+    // Prints the error code(s) if OpenGL errors have ocurred since the last invocation
+    void checkError(int ignore = 0);
 
   }  // namespace glstate
 }  // namespace wren

--- a/src/wren/GlState.hpp
+++ b/src/wren/GlState.hpp
@@ -129,7 +129,7 @@ namespace wren {
     const UniformBuffer *uniformBuffer(WrGlslLayoutUniformBuffer buffer);
 
     // Returns true and prints the error code(s) if OpenGL errors have ocurred since the last invocation
-    bool checkError();
+    bool checkError(int ignore = 0);
 
   }  // namespace glstate
 }  // namespace wren


### PR DESCRIPTION
As reported by a user the GPU memory reading on AMD graphics cards was broken, probably due to an update of the AMD driver. This PR fixes the problem.