### PR TITLE
 Fix controller builds using a custom Java Makefile.

### DIFF
--- a/change_logs/ChangeLog.html
+++ b/change_logs/ChangeLog.html
@@ -19,6 +19,7 @@ Released on xx xxth, 2019
 </ul>
 <li><b>Bug fixes</b></li>
 <ul>
+<li>Fixed controller builds using a custom Java Makefile.</li>
 <li>Fixed Fog node not disabled when visibility range is 0.</li>
 <li>Fixed reading of available GPU memory on some AMD graphics cards.</li>
 <li>Fixed crash when adding a geometry node in the 'animatedGeometry' field of the Track node.</li>

--- a/resources/Makefile.java.include
+++ b/resources/Makefile.java.include
@@ -93,9 +93,6 @@ endif
 
 .PHONY: all clean release debug profile
 
-clean:
-	@rm -fr *.class  *.jar > /dev/null 2>&1 || :
-
 ifeq ($(JAVA_HOME),)
 release debug profile:
 	@echo -e "# \033[0;33mJava not installed or 'JAVA_HOME' not set, skipping Java API\033[0m"
@@ -112,3 +109,6 @@ $(JAR_FILE):
 
 jar: $(JAR_FILE)
 endif
+
+clean:
+	@rm -fr *.class  *.jar > /dev/null 2>&1 || :


### PR DESCRIPTION
When compiling a Java controller in the GUI having a custom Makefile, `make -jX` is called. The first rule of the Makefile is called in this default case. Currently, the first rule is `clean`; this mechanism is broken.