### PR TITLE
Fix shadows in pick and place benchmark

### DIFF
--- a/projects/objects/apartment_structure/protos/Ceiling.proto
+++ b/projects/objects/apartment_structure/protos/Ceiling.proto
@@ -11,6 +11,7 @@ PROTO Ceiling [
   field SFVec2f    size             10 10                                                            # Defines the size of the ceiling.
   field SFNode     appearance       Roughcast { textureTransform TextureTransform { scale 10 10 } }  # Defines the appearance of the ceiling.
   field SFBool     locked           TRUE                                                             # Is `Solid.locked`.
+  field SFBool     castShadows      TRUE                                                             # Defines whether this object should cast shadows.
 ]
 {
   Solid {
@@ -22,6 +23,7 @@ PROTO Ceiling [
         geometry Plane {
           size IS size
         }
+        castShadows IS castShadows
       }
     ]
     name IS name

--- a/projects/objects/apartment_structure/protos/DoorKnob.proto
+++ b/projects/objects/apartment_structure/protos/DoorKnob.proto
@@ -14,6 +14,7 @@ PROTO DoorKnob [
   field SFFloat    distanceFromDoor 0.065                # Defines the distance between the handle and the door.
   field SFNode     appearance       BrushedAluminium {}  # Defines the appearance of the handle.
   field SFFloat    mass             0.7                  # Defines the mass of the handle.
+  field SFBool     castShadows      TRUE                 # Defines whether this object should cast shadows.
 ]
 {
   %{
@@ -53,6 +54,7 @@ PROTO DoorKnob [
                 radius 0.03
                 height %{= 0.025 + doorThickness }%
               }
+              castShadows IS castShadows
             }
           ]
         }
@@ -65,6 +67,7 @@ PROTO DoorKnob [
                 radius %{= 0.4 * handleRadius }%
                 height %{= axisHeight }%
               }
+              castShadows IS castShadows
             }
           ]
         }
@@ -78,6 +81,7 @@ PROTO DoorKnob [
                 radius %{= handleRadius }%
                 subdivision 2
               }
+              castShadows IS castShadows
             }
           ]
         }
@@ -91,6 +95,7 @@ PROTO DoorKnob [
                 radius %{= handleRadius }%
                 subdivision 2
               }
+              castShadows IS castShadows
             }
           ]
         }

--- a/projects/objects/apartment_structure/protos/DoorLever.proto
+++ b/projects/objects/apartment_structure/protos/DoorLever.proto
@@ -18,6 +18,7 @@ PROTO DoorLever [
   field SFNode     appearance       BrushedAluminium {}  # Defines the appearance of the lever.
   field SFFloat    mass             0.7                  # Defines the mass of the lever.
   field SFBool     hasStaticParent  FALSE                # Defines whether the parent door has physics or not.
+  field SFBool     castShadows      TRUE                 # Defines whether this object should cast shadows.
 ]
 {
   %{
@@ -66,6 +67,7 @@ PROTO DoorLever [
                 radius %{= 3 * handleThickness }%
                 height %{= 0.025 + doorThickness }%
               }
+              castShadows IS castShadows
             }
           ]
         }
@@ -96,6 +98,7 @@ PROTO DoorLever [
                       radius %{= handleThickness }%
                       height %{= axisHeight }%
                     }
+                    castShadows IS castShadows
                   }
                 ]
               }
@@ -109,6 +112,7 @@ PROTO DoorLever [
                       radius %{= handleThickness }%
                       height %{= handleLength }%
                     }
+                    castShadows IS castShadows
                   }
                 ]
               }
@@ -122,6 +126,7 @@ PROTO DoorLever [
                       radius %{= handleThickness }%
                       height %{= handleLength }%
                     }
+                    castShadows IS castShadows
                   }
                 ]
               }

--- a/projects/samples/robotbenchmark/pick_and_place/worlds/pick_and_place.wbt
+++ b/projects/samples/robotbenchmark/pick_and_place/worlds/pick_and_place.wbt
@@ -79,6 +79,7 @@ DEF WALL Solid {
       geometry Plane {
         size 12 5
       }
+      castShadows FALSE
     }
   ]
   boundingObject USE WALL_SHAPE
@@ -113,6 +114,7 @@ DEF WALL Solid {
 Ceiling {
   translation 0 5 0
   size 12 12
+  castShadows FALSE
 }
 Door {
   translation -2.44 0 -5.99
@@ -122,7 +124,9 @@ Door {
     translation 0 0.045 0
     mass 0
     hasStaticParent TRUE
+    castShadows FALSE
   }
+  castShadows FALSE
 }
 DEF PIPES Group {
   children [


### PR DESCRIPTION
Improve exported `pick_and_place.wbt` in THREEjs by unsetting the castShadows flag for walls, door and ceiling.