### PR TITLE
Remove invalid option --enable-ogre-warnings from documentation

### DIFF
--- a/docs/guide/starting-webots.md
+++ b/docs/guide/starting-webots.md
@@ -113,8 +113,6 @@ For example, the following command will start Webots with the streaming server e
 
 You can get more information about web streaming in [this section](web-streaming.md).
 
-The `--enable-ogre-warnings` option redirects the uncritical Ogre log messages to the Webots console.
-The critical Ogre log messages are redirected there in any case.
 If the `--stdout` option is enabled then the uncritical Ogre log messages are redirected to the *stdout* stream of the Webots executable instead.
 Similarily, the `--stderr` option is redirecting the Ogre critical messages to the *stderr* stream.
 


### PR DESCRIPTION
Using the option results in the following error:

```
$ webots  --enable-ogre-warnings
webots: invalid option: '--enable-ogre-warnings'
Try 'webots --help' for more information.
```