### PR TITLE
Fix check for Hinge2Joint ancestor when inserting a Muscle

### DIFF
--- a/change_logs/ChangeLog.html
+++ b/change_logs/ChangeLog.html
@@ -25,6 +25,7 @@ Released on xx xxth, 2019
 <li>Fixed crash when adding a geometry node in the 'animatedGeometry' field of the Track node.</li>
 <li>Fixed calibration of the Khepera4 robot ground sensors (thanks to Jeremy and Cyrill).</li>
 <li>Fixed crash when copy-pasting some procedural nodes.</li>
+<li>Fixed availability of Muscle node in case of an Hinge2Joint ancestor (thanks to Florin).</li>
 </ul>
 </ul>
 

--- a/src/webots/nodes/utils/WbNodeUtilities.cpp
+++ b/src/webots/nodes/utils/WbNodeUtilities.cpp
@@ -397,9 +397,9 @@ namespace {
 
     } else if (fieldName == "muscles" && (parentModelName == "LinearMotor" || parentModelName == "RotationalMotor")) {
       QString invalidParentNode;
-      if (WbNodeUtilities::findUpperNodeByType(node, WB_NODE_TRACK))
+      if (WbNodeUtilities::findUpperNodeByType(node, WB_NODE_TRACK, 1))
         invalidParentNode = "Track";
-      else if (WbNodeUtilities::findUpperNodeByType(node, WB_NODE_HINGE_2_JOINT))
+      else if (WbNodeUtilities::findUpperNodeByType(node, WB_NODE_HINGE_2_JOINT, 1))
         invalidParentNode = "Hinge2Joint";
 
       if (!invalidParentNode.isEmpty()) {
@@ -535,15 +535,17 @@ namespace {
   }
 };  // namespace
 
-WbNode *WbNodeUtilities::findUpperNodeByType(const WbNode *node, int nodeType) {
+WbNode *WbNodeUtilities::findUpperNodeByType(const WbNode *node, int nodeType, int searchDegrees) {
   if (node == NULL)
     return NULL;
 
+  int count = searchDegrees > 0 ? searchDegrees : -1;
   WbBaseNode *n = dynamic_cast<WbBaseNode *>(node->parent());
-  while (n) {
+  while (n && count != 0) {
     if (n->nodeType() == nodeType)
       return n;
     n = dynamic_cast<WbBaseNode *>(n->parent());
+    count--;
   }
   return NULL;
 }

--- a/src/webots/nodes/utils/WbNodeUtilities.hpp
+++ b/src/webots/nodes/utils/WbNodeUtilities.hpp
@@ -63,7 +63,8 @@ namespace WbNodeUtilities {
   WbMatter *findUpperMatter(const WbNode *node);
 
   // find the closest ancestor of specified type
-  WbNode *findUpperNodeByType(const WbNode *node, int nodeType);
+  // searchDegree specifies how many ancestor have to be checked, if lower or equal to 0 all the hierarchy is inspected
+  WbNode *findUpperNodeByType(const WbNode *node, int nodeType, int searchDegrees = 0);
 
   // return if this node contains descendant nodes of the specified types
   bool hasDescendantNodesOfType(const WbNode *node, QList<int> nodeTypes);


### PR DESCRIPTION
Muscle are not available for Hinge2Joint, but the check was mistakenly checking the whole ancestor hierarchy instead of stopping at the first joint instance.