### PR TITLE
Improve default SpotLight.beamWidth default value

### DIFF
--- a/change_logs/ChangeLog.html
+++ b/change_logs/ChangeLog.html
@@ -41,6 +41,7 @@ Released on xx xxth, 2019
 <li>Connector nodes can now be inserted in Solid nodes.</li>
 <li>Connector nodes can now be part of the static environment.</li>
 <li>Improved the infra-red DistanceSensor model by taking into account the roughness and occlusion of the surface.</li>
+<li>Improved the default SpotLight.beamWidth value.</li>
 </ul>
 <li><b>Bug fix</b></li>
 <ul>

--- a/resources/nodes/SpotLight.wrl
+++ b/resources/nodes/SpotLight.wrl
@@ -4,7 +4,7 @@
 SpotLight {
   vrmlField SFFloat ambientIntensity  0        # [0,1]
   vrmlField SFVec3f attenuation       1 0 0    # [0,)
-  vrmlField SFFloat beamWidth         1.570796 # [0,)
+  vrmlField SFFloat beamWidth         0.785398 # [0,)
   vrmlField SFColor color             1 1 1    # [0,1]
   vrmlField SFFloat cutOffAngle       0.785398 # [0,)
   vrmlField SFVec3f direction         0 0 -1   # (-,)

--- a/resources/nodes/SpotLight.wrl
+++ b/resources/nodes/SpotLight.wrl
@@ -4,7 +4,7 @@
 SpotLight {
   vrmlField SFFloat ambientIntensity  0        # [0,1]
   vrmlField SFVec3f attenuation       1 0 0    # [0,)
-  vrmlField SFFloat beamWidth         0.785398 # [0,)
+  vrmlField SFFloat beamWidth         0.7      # [0,)
   vrmlField SFColor color             1 1 1    # [0,1]
   vrmlField SFFloat cutOffAngle       0.785398 # [0,)
   vrmlField SFVec3f direction         0 0 -1   # (-,)


### PR DESCRIPTION
Currently the default values match the VRML ones but it is not a valid setup in Webots given that there is the constraint that `beamWidth` has to be less or equal to `cutOffAngle`.