### PR TITLE
Fix Windows Packaging on Develop

### DIFF
--- a/src/packaging/exist_in_projects_windows.txt
+++ b/src/packaging/exist_in_projects_windows.txt
@@ -1,3 +1,1 @@
-projects/default/libraries/ros/libroscpp.dll
-projects/default/controllers/ros/include/XmlRpcDecl.h
-projects/default/controllers/ros/include/XmlRpcValue.h
+


### PR DESCRIPTION
We do not distribute the CPP version of the ROS controller on Windows anymore.