### PR TITLE
Improve Spotlight default beamWidth

### DIFF
--- a/change_logs/ChangeLog.html
+++ b/change_logs/ChangeLog.html
@@ -41,6 +41,7 @@ Released on xx xxth, 2019
 <li>Connector nodes can now be inserted in Solid nodes.</li>
 <li>Connector nodes can now be part of the static environment.</li>
 <li>Improved the infra-red DistanceSensor model by taking into account the roughness and occlusion of the surface.</li>
+<li>Improved the default SpotLight.beamWidth value.</li>
 </ul>
 <li><b>Bug fix</b></li>
 <ul>

--- a/resources/nodes/SpotLight.wrl
+++ b/resources/nodes/SpotLight.wrl
@@ -4,7 +4,7 @@
 SpotLight {
   vrmlField SFFloat ambientIntensity  0        # [0,1]
   vrmlField SFVec3f attenuation       1 0 0    # [0,)
-  vrmlField SFFloat beamWidth         0.7      # [0,)
+  vrmlField SFFloat beamWidth         1.570796 # [0,)
   vrmlField SFColor color             1 1 1    # [0,1]
   vrmlField SFFloat cutOffAngle       0.785398 # [0,)
   vrmlField SFVec3f direction         0 0 -1   # (-,)

--- a/resources/nodes/SpotLight.wrl
+++ b/resources/nodes/SpotLight.wrl
@@ -4,7 +4,7 @@
 SpotLight {
   vrmlField SFFloat ambientIntensity  0        # [0,1]
   vrmlField SFVec3f attenuation       1 0 0    # [0,)
-  vrmlField SFFloat beamWidth         1.570796 # [0,)
+  vrmlField SFFloat beamWidth         0.785398 # [0,)
   vrmlField SFColor color             1 1 1    # [0,1]
   vrmlField SFFloat cutOffAngle       0.785398 # [0,)
   vrmlField SFVec3f direction         0 0 -1   # (-,)

--- a/resources/nodes/SpotLight.wrl
+++ b/resources/nodes/SpotLight.wrl
@@ -4,7 +4,7 @@
 SpotLight {
   vrmlField SFFloat ambientIntensity  0        # [0,1]
   vrmlField SFVec3f attenuation       1 0 0    # [0,)
-  vrmlField SFFloat beamWidth         0.785398 # [0,)
+  vrmlField SFFloat beamWidth         0.7      # [0,)
   vrmlField SFColor color             1 1 1    # [0,1]
   vrmlField SFFloat cutOffAngle       0.785398 # [0,)
   vrmlField SFVec3f direction         0 0 -1   # (-,)

--- a/src/webots/nodes/WbSpotLight.cpp
+++ b/src/webots/nodes/WbSpotLight.cpp
@@ -48,10 +48,11 @@ void WbSpotLight::init() {
 
 WbSpotLight::WbSpotLight(WbTokenizer *tokenizer) : WbLight("SpotLight", tokenizer) {
   init();
-  if (tokenizer == NULL)
+  if (tokenizer == NULL) {
     mDirection->setValueNoSignal(0, 1, -1);
-  if (tokenizer == NULL)
     mAttenuation->setValueNoSignal(0.0, 0.0, 1.0);
+    mBeamWidth->setValueNoSignal(0.7);
+  }
 }
 
 WbSpotLight::WbSpotLight(const WbSpotLight &other) : WbLight(other) {


### PR DESCRIPTION
Use 0.7 instead of 0.758 as default SpotLight.beamWidth in Webots to have a nicer effect.