### PR TITLE
macOS: Fix build warnings

### DIFF
--- a/src/webots/Makefile
+++ b/src/webots/Makefile
@@ -101,6 +101,8 @@ LD_FLAGS += -lpthread
 else
 LD_FLAGS += -lode
 endif
+# To link with libpico without warnings about the "register" keyword.
+CFLAGS += -Wno-deprecated-register
 
 else ifeq ($(OSTYPE),linux)
 LIB_WREN           = ../wren/libwren.a ../glad/libglad.a

--- a/src/webots/Makefile
+++ b/src/webots/Makefile
@@ -101,7 +101,7 @@ LD_FLAGS += -lpthread
 else
 LD_FLAGS += -lode
 endif
-# To link with libpico without warnings about the "register" keyword.
+# To compile with libpico without warnings about the "register" keyword.
 CFLAGS += -Wno-deprecated-register
 
 else ifeq ($(OSTYPE),linux)

--- a/src/webots/Makefile
+++ b/src/webots/Makefile
@@ -176,7 +176,7 @@ LIBS += -lode
 endif
 endif
 
-ALL_INCLUDE        = -Iapp -Icontrol -Icore -Iwidgets -Ieditor -Iengine -isystem external/siphash -isystem external/stb_image -Igui -Imaths -Inodes -Inodes/utils -Iplugins -Iscene_tree -Isound -Iuser_commands -Ivrml -Iutil
+ALL_INCLUDE        = -Iapp -Icontrol -Icore -Iwidgets -Ieditor -Iengine -isystem external/siphash -isystem external/stb_image -Igui -Imaths -Inodes -Inodes/utils -Iplugins -Iscene_tree -Isound -Iuser_commands -Ivrml -Iutil -Iexternal/compilation_timestamp
 
 CONTROLLER_INCLUDE = -I$(WEBOTS_PATH)/include/controller/c
 ODE_INCLUDE        = -Iode -isystem $(WEBOTS_PATH)/include/ode


### PR DESCRIPTION
Fix two kind of warnings since the last clang upgrade:

1. warning about the use of the `register` keyword when linking with libpico:

        ../../include/libpico/picoknow.h:167:53: warning: 'register' storage class specifier is deprecated and incompatible with C++17 [-Wdeprecated-register]
        typedef pico_status_t (* picoknow_kbSubDeallocate) (register picoknow_KnowledgeBase that, picoos_MemoryManager mm);
                                                            ^~~~~~~~~

2. 'compilation_timestamp.h' not found

        core/WbTelemetry.cpp:24:10: 'compilation_timestamp.h' file not found
        #include <compilation_timestamp.h>
                 ^~~~~~~~~~~~~~~~~~~~~~~~~
