### PR TITLE
Fix Floor proto

### DIFF
--- a/change_logs/ChangeLog.html
+++ b/change_logs/ChangeLog.html
@@ -47,6 +47,7 @@ Released on xx xxth, 2019
 <ul>
 <li>Renamed some PROTO appearances ('MatteCarPaint' -> 'MattePaint', 'GlossyCarPaint' -> 'GlossyPaint', 'CarLeather' -> 'Leather').</li>
 <li>Fixed DoorLever 'name' field not connected when its 'canTurn' field is set to TRUE.</li>
+<li>Fixed mirrored texture in Floor PROTO.</li>
 </ul>
 <li><b>Cleanup</b></li>
 <ul>

--- a/projects/objects/floors/protos/Floor.proto
+++ b/projects/objects/floors/protos/Floor.proto
@@ -65,7 +65,7 @@ PROTO Floor [
             0 2 3 1 -1
           ]
           texCoordIndex [
-            0 2 3 1 -1
+            2 0 1 3 -1
           ]
         }
       }

--- a/projects/samples/robotbenchmark/humanoid_sprint/worlds/humanoid_sprint.wbt
+++ b/projects/samples/robotbenchmark/humanoid_sprint/worlds/humanoid_sprint.wbt
@@ -33,18 +33,30 @@ TexturedBackgroundLight {
 DEF TRACK Floor {
   size 11.78 3
   tileSize 11.78 3
-  texture [
-    "textures/nao_10m_track.jpg"
-  ]
+  appearance PBRAppearance {
+    baseColorMap ImageTexture {
+      url [
+        "textures/nao_10m_track.jpg"
+      ]
+    }
+    roughness 1
+    metalness 0
+  }
 }
 DEF GRASS Floor {
   translation 0 -0.005 0
   name "grass"
   size 20 10
   tileSize 1 1
-  texture [
-    "textures/grass.jpg"
-  ]
+  appearance PBRAppearance {
+    baseColorMap ImageTexture {
+      url [
+        "textures/grass.jpg"
+      ]
+    }
+    roughness 1
+    metalness 0
+  }
 }
 DEF NAO Nao {
   translation -5.345 0.334 -0.65


### PR DESCRIPTION
Address #304:
- Floor PROTO instances in `humanoid_sprint.wbt` are outdated
- texture mapping in Floor PROTO is wrong and displays mirrored textured