### PR TITLE
Upgraded to new version of ICU

### DIFF
--- a/src/packaging/files_msys64.txt
+++ b/src/packaging/files_msys64.txt
@@ -16,9 +16,9 @@
 /mingw64/bin/Qt5WebSockets.dll
 /mingw64/bin/Qt5Widgets.dll
 /mingw64/bin/Qt5Xml.dll
-/mingw64/bin/libicuuc62.dll
-/mingw64/bin/libicuin62.dll
-/mingw64/bin/libicudt62.dll
+/mingw64/bin/libicuuc64.dll
+/mingw64/bin/libicuin64.dll
+/mingw64/bin/libicudt64.dll
 /mingw64/bin/libminizip-1.dll
 /mingw64/bin/libstdc++-6.dll
 /mingw64/bin/libgcc_s_seh-1.dll


### PR DESCRIPTION
Since the last update of MSYS2, Qt5 was upgraded to use ICU version 64 instead of 62. Hence our installation script should be updated accordingly.

👍