### PR TITLE
Added Python3 path before msys2 path to prevent python conflicts

### DIFF
--- a/src/install_scripts/msys.sh
+++ b/src/install_scripts/msys.sh
@@ -7,6 +7,6 @@ cd ~
 else
 WINDOWS_DRIVE=${1:1:1}:\\${1:3}
 export WEBOTS_HOME=${WINDOWS_DRIVE////\\}
-export PATH="$1/msys64/mingw64/bin":/mingw64/bin:/usr/bin:$PYTHON37_HOME:$PYTHON37_HOME/Scripts:$JAVA_HOME/bin:/c/WINDOWS/system32:/c/WINDOWS:$MATLAB_HOME/bin
+export PATH="$PYTHON37_HOME:$PYTHON37_HOME/Scripts:$1/msys64/mingw64/bin":/mingw64/bin:/usr/bin:$JAVA_HOME/bin:/c/WINDOWS/system32:/c/WINDOWS:$MATLAB_HOME/bin
 cd "$1"
 fi


### PR DESCRIPTION
This fixes a problem on Windows where the MSYS2 python command was used instead of the official Python3, thus causing a failure of the main build process during the compilation of the Python3 wrapper (Python.h was not found).

👍