### PR TITLE
Hotfix reusing an already loaded texture in webots.js

### DIFF
--- a/resources/web/wwi/texture_loader.js
+++ b/resources/web/wwi/texture_loader.js
@@ -7,7 +7,7 @@ var TextureLoader = {
     console.assert(typeof name === 'string', 'TextureLoader.loadOrRetrieve: name is not a string.');
     if (typeof name === 'undefined' || name === '')
       return undefined;
-    this._getInstance().loadOrRetrieve(name, texture, cubeTextureIndex);
+    return this._getInstance().loadOrRetrieve(name, texture, cubeTextureIndex);
   },
 
   loadFromUri: function(uri, name) {


### PR DESCRIPTION
Fix TextureLoader interface to propagating the texture if it was already loaded and cached.