### PR TITLE
Add round to time 

### DIFF
--- a/projects/default/controllers/ros/Ros.cpp
+++ b/projects/default/controllers/ros/Ros.cpp
@@ -439,7 +439,8 @@ void Ros::run(int argc, char **argv) {
       rosgraph_msgs::Clock simulationClock;
       double time = mRobot->getTime();
       simulationClock.clock.sec = (int)time;
-      simulationClock.clock.nsec = round(1000 * (time - simulationClock.clock.sec)) * 1.0e+6;  // the round prevents precision issues that can then cause issue when using ros timers
+      // round prevents precision issues that can cause problems with ROS timers
+      simulationClock.clock.nsec = round(1000 * (time - simulationClock.clock.sec)) * 1.0e+6;
       mClockPublisher.publish(simulationClock);
     }
     for (unsigned int i = 0; i < mSensorList.size(); i++)

--- a/projects/default/controllers/ros/Ros.cpp
+++ b/projects/default/controllers/ros/Ros.cpp
@@ -439,7 +439,7 @@ void Ros::run(int argc, char **argv) {
       rosgraph_msgs::Clock simulationClock;
       double time = mRobot->getTime();
       simulationClock.clock.sec = (int)time;
-      simulationClock.clock.nsec = (time - simulationClock.clock.sec) * 1.0e+9;
+      simulationClock.clock.nsec = round(time - simulationClock.clock.sec) * 1.0e+9;
       mClockPublisher.publish(simulationClock);
     }
     for (unsigned int i = 0; i < mSensorList.size(); i++)

--- a/projects/default/controllers/ros/Ros.cpp
+++ b/projects/default/controllers/ros/Ros.cpp
@@ -439,7 +439,7 @@ void Ros::run(int argc, char **argv) {
       rosgraph_msgs::Clock simulationClock;
       double time = mRobot->getTime();
       simulationClock.clock.sec = (int)time;
-      simulationClock.clock.nsec = round(time - simulationClock.clock.sec) * 1.0e+9;
+      simulationClock.clock.nsec = round(1000 * (time - simulationClock.clock.sec)) * 1.0e+6;  // the round prevents precision issues that can then cause issue when using ros timers
       mClockPublisher.publish(simulationClock);
     }
     for (unsigned int i = 0; i < mSensorList.size(); i++)


### PR DESCRIPTION
Hello Webots team,

today I was struggling with the time published by webots on the "/clock" topic when synchronizing with ROS.
The problem: - Sometimes the calculated times don't exactly match the expected times:
 
e.g. instead of 
`sec: 11
nsec: 120000000`

Webots was publishing:
`sec: 11
nsec: 119999999`

I'm not quite sure why this only happens sometimes (randomly), but I guess it might be a bit problem when multiplying both doubles.
On the first hand it doesn't look like a big deal but gives you headache if you want to use timer events in ROS (http://wiki.ros.org/roscpp/Overview/Timers), because the event might not be triggered for the second case.
Adding the round function helps getting the expected values to be published

