### PR TITLE
Fixed link failure if Webots installation folder contains parenthesis

### DIFF
--- a/resources/Makefile.include
+++ b/resources/Makefile.include
@@ -305,7 +305,7 @@ ifdef USE_CXX
   LINKER = $(CXX)
  endif
  ifndef EXCLUDE_CONTROLLERS
-  DYNAMIC_LIBRARIES += -L$(WEBOTS_LIB_PATH) -lController
+  DYNAMIC_LIBRARIES += -L"$(WEBOTS_LIB_PATH)" -lController
   ifdef USE_C_API
    INCLUDE += -I"$(WEBOTS_HOME)/include/controller/c"
   else
@@ -328,7 +328,7 @@ else
  endif
  ifndef EXCLUDE_CONTROLLERS
   INCLUDE += -I"$(WEBOTS_HOME)/include/controller/c"
-  DYNAMIC_LIBRARIES += -L$(WEBOTS_LIB_PATH) -lController
+  DYNAMIC_LIBRARIES += -L"$(WEBOTS_LIB_PATH)" -lController
  endif
 endif
 
@@ -380,7 +380,7 @@ endif
 ###-----------------------------------------------------------------------------
 
 ifdef USE_ODE
- DYNAMIC_LIBRARIES += -L$(WEBOTS_LIB_PATH) -lode "$(WEBOTS_HOME)/resources/projects/plugins/physics/physics.o"
+ DYNAMIC_LIBRARIES += -L"$(WEBOTS_LIB_PATH)" -lode "$(WEBOTS_HOME)/resources/projects/plugins/physics/physics.o"
  ifeq ($(GOAL),profile)
   DYNAMIC_LIBRARIES += -lstdc++
  endif
@@ -570,7 +570,7 @@ ifdef MAIN_TARGET
 
 MAIN_TARGET_WINDOWS_LIB = $(MAIN_TARGET:.dll=.lib)
 ifdef WEBOTS_LIBRARY
-MAIN_TARGET_COPY = "$(subst $(space),\ ,$(strip $(subst \,/,$(WEBOTS_LIB_PATH))))/$(MAIN_TARGET)"
+MAIN_TARGET_COPY = "$(subst $(space),\ ,$(WEBOTS_LIB_PATH))/$(MAIN_TARGET)"
 MAIN_TARGET_WINDOWS32_LIB = $(WEBOTS_HOME_PATH)/msys64/mingw32/lib/$(MAIN_TARGET_WINDOWS_LIB)
 MAIN_TARGET_WINDOWS64_LIB = $(WEBOTS_HOME_PATH)/msys64/mingw64/lib/$(MAIN_TARGET_WINDOWS_LIB)
 else

--- a/resources/Makefile.os.include
+++ b/resources/Makefile.os.include
@@ -86,7 +86,7 @@ STATIC_LIB_EXTENSION = .a
 ifeq ($(OSTYPE),windows)
  EXE_EXTENSION = .exe
  SHARED_LIB_EXTENSION = .dll
- WEBOTS_LIB_PATH=$(WEBOTS_HOME_PATH)/msys64/mingw64/bin
+ WEBOTS_LIB_PATH=$(subst \,/,$(WEBOTS_HOME))/msys64/mingw64/bin
 else
  LIB_PREFIX = lib
  WEBOTS_LIB_PATH=$(WEBOTS_HOME)/lib


### PR DESCRIPTION
This patch fixes a problem reported by a user:
![___](https://user-images.githubusercontent.com/1264964/57127531-ff73ad00-6d90-11e9-8efc-de050b987883.png)
