### PR TITLE
Run test_suite in Batch Mode

### DIFF
--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -208,7 +208,7 @@ finalMessage = 'Test suite complete'
 thread = threading.Thread(target=monitorOutputFile, args=[finalMessage])
 thread.start()
 
-webotsArguments = '--mode=fast --stdout --stderr --minimize'
+webotsArguments = '--mode=fast --stdout --stderr --minimize --batch'
 
 for groupName in testGroups:
 


### PR DESCRIPTION
This will prevent Webots been stuck on the welcome dialog on jenkins each time we update the version (see  #422).