### PR TITLE
Fix calls to geometries sanitizeFields

### DIFF
--- a/src/webots/nodes/WbBox.cpp
+++ b/src/webots/nodes/WbBox.cpp
@@ -71,6 +71,8 @@ void WbBox::createWrenObjects() {
   WbGeometry::createWrenObjects();
   WbGeometry::computeWrenRenderable();
 
+  sanitizeFields();
+
   const bool createOutlineMesh = isInBoundingObject();
   mWrenMesh = wr_static_mesh_unit_box_new(createOutlineMesh);
 
@@ -161,7 +163,7 @@ void WbBox::updateSize() {
 }
 
 void WbBox::updateLineScale() {
-  if (!sanitizeFields() || !isAValidBoundingObject())
+  if (!isAValidBoundingObject())
     return;
 
   float offset = wr_config_get_line_scale() / LINE_SCALE_FACTOR;
@@ -173,9 +175,6 @@ void WbBox::updateLineScale() {
 }
 
 void WbBox::updateScale() {
-  if (!sanitizeFields())
-    return;
-
   float scale[] = {static_cast<float>(mSize->value().x()), static_cast<float>(mSize->value().y()),
                    static_cast<float>(mSize->value().z())};
   wr_transform_set_scale(wrenNode(), scale);

--- a/src/webots/nodes/WbCapsule.cpp
+++ b/src/webots/nodes/WbCapsule.cpp
@@ -87,6 +87,7 @@ void WbCapsule::createWrenObjects() {
   if (isInBoundingObject())
     connect(WbWrenRenderingContext::instance(), &WbWrenRenderingContext::lineScaleChanged, this, &WbCapsule::updateLineScale);
 
+  sanitizeFields();
   buildWrenMesh();
 
   emit wrenObjectsCreated();
@@ -137,9 +138,6 @@ void WbCapsule::buildWrenMesh() {
 
   wr_static_mesh_delete(mWrenMesh);
   mWrenMesh = NULL;
-
-  if (!sanitizeFields())
-    return;
 
   if (mBottom->isFalse() && mSide->isFalse() && mTop->isFalse())
     return;
@@ -270,7 +268,7 @@ void WbCapsule::updateSubdivision() {
 }
 
 void WbCapsule::updateLineScale() {
-  if (!sanitizeFields() || !isAValidBoundingObject())
+  if (!isAValidBoundingObject())
     return;
 
   float offset = wr_config_get_line_scale() / LINE_SCALE_FACTOR;

--- a/src/webots/nodes/WbCone.cpp
+++ b/src/webots/nodes/WbCone.cpp
@@ -76,6 +76,7 @@ void WbCone::postFinalize() {
 void WbCone::createWrenObjects() {
   WbGeometry::createWrenObjects();
 
+  sanitizeFields();
   buildWrenMesh();
 
   emit wrenObjectsCreated();
@@ -130,9 +131,6 @@ void WbCone::buildWrenMesh() {
 
   wr_static_mesh_delete(mWrenMesh);
   mWrenMesh = NULL;
-
-  if (!sanitizeFields())
-    return;
 
   if (mBottom->isFalse() && mSide->isFalse())
     return;
@@ -242,9 +240,6 @@ void WbCone::updateSubdivision() {
 }
 
 void WbCone::updateScale() {
-  if (!sanitizeFields())
-    return;
-
   float scale[] = {static_cast<float>(mBottomRadius->value()), static_cast<float>(mHeight->value()),
                    static_cast<float>(mBottomRadius->value())};
   wr_transform_set_scale(wrenNode(), scale);

--- a/src/webots/nodes/WbCylinder.cpp
+++ b/src/webots/nodes/WbCylinder.cpp
@@ -91,6 +91,7 @@ void WbCylinder::createWrenObjects() {
   if (isInBoundingObject())
     connect(WbWrenRenderingContext::instance(), &WbWrenRenderingContext::lineScaleChanged, this, &WbCylinder::updateLineScale);
 
+  sanitizeFields();
   buildWrenMesh();
 
   emit wrenObjectsCreated();
@@ -146,9 +147,6 @@ void WbCylinder::buildWrenMesh() {
 
   wr_static_mesh_delete(mWrenMesh);
   mWrenMesh = NULL;
-
-  if (!sanitizeFields())
-    return;
 
   if (mBottom->isFalse() && mSide->isFalse() && mTop->isFalse())
     return;
@@ -276,7 +274,7 @@ void WbCylinder::updateSubdivision() {
 }
 
 void WbCylinder::updateLineScale() {
-  if (!isAValidBoundingObject() || !sanitizeFields())
+  if (!isAValidBoundingObject())
     return;
 
   float offset = wr_config_get_line_scale() / LINE_SCALE_FACTOR;
@@ -288,9 +286,6 @@ void WbCylinder::updateLineScale() {
 }
 
 void WbCylinder::updateScale() {
-  if (!sanitizeFields())
-    return;
-
   float scale[] = {static_cast<float>(mRadius->value()), static_cast<float>(mHeight->value()),
                    static_cast<float>(mRadius->value())};
   wr_transform_set_scale(wrenNode(), scale);

--- a/src/webots/nodes/WbElevationGrid.cpp
+++ b/src/webots/nodes/WbElevationGrid.cpp
@@ -84,8 +84,6 @@ void WbElevationGrid::preFinalize() {
   if (color())
     color()->preFinalize();
 
-  sanitizeFields();
-
   if (isInBoundingObject()) {
     if (WbNodeUtilities::findUpperMatter(this)->nodeType() == WB_NODE_FLUID) {
       warn("The ElevationGrid geometry cannot be used as a Fluid boundingObject. Immersions will have not effect.\n");
@@ -116,6 +114,7 @@ void WbElevationGrid::postFinalize() {
 
 void WbElevationGrid::createWrenObjects() {
   WbGeometry::createWrenObjects();
+  sanitizeFields();
   updateColor();
 
   buildWrenMesh();
@@ -133,9 +132,6 @@ void WbElevationGrid::buildWrenMesh() {
 
   wr_static_mesh_delete(mWrenMesh);
   mWrenMesh = NULL;
-
-  if (!sanitizeFields())
-    return;
 
   if (xDimension() < 2 || zDimension() < 2)
     return;
@@ -372,7 +368,7 @@ void WbElevationGrid::updateZSpacing() {
 }
 
 void WbElevationGrid::updateLineScale() {
-  if (!sanitizeFields() || !isAValidBoundingObject())
+  if (!isAValidBoundingObject())
     return;
 
   const float offset = wr_config_get_line_scale() / LINE_SCALE_FACTOR;
@@ -383,9 +379,6 @@ void WbElevationGrid::updateLineScale() {
 }
 
 void WbElevationGrid::updateScale() {
-  if (!sanitizeFields())
-    return;
-
   float scale[] = {static_cast<float>(xSpacing()), static_cast<float>(1.0f), static_cast<float>(zSpacing())};
   wr_transform_set_scale(wrenNode(), scale);
 }

--- a/src/webots/nodes/WbIndexedLineSet.cpp
+++ b/src/webots/nodes/WbIndexedLineSet.cpp
@@ -76,6 +76,7 @@ void WbIndexedLineSet::createWrenObjects() {
     connect(WbWrenRenderingContext::instance(), &WbWrenRenderingContext::lineScaleChanged, this,
             &WbIndexedLineSet::updateLineScale);
 
+  sanitizeFields();
   buildWrenMesh();
 
   emit wrenObjectsCreated();
@@ -121,9 +122,6 @@ void WbIndexedLineSet::buildWrenMesh() {
   WbGeometry::computeWrenRenderable();
 
   wr_renderable_set_drawing_mode(mWrenRenderable, WR_RENDERABLE_DRAWING_MODE_LINES);
-
-  if (!sanitizeFields())
-    return;
 
   // In the worst case we end up with 2 * mCoordIndex->size() - 1 coordinates
   float *coordsData = new float[mCoordIndex->size() * 6];
@@ -185,6 +183,9 @@ int WbIndexedLineSet::computeCoordsData(float *data) {
 }
 
 void WbIndexedLineSet::updateCoord() {
+  if (!sanitizeFields())
+    return;
+
   if (coord())
     connect(coord(), &WbCoordinate::fieldChanged, this, &WbIndexedLineSet::updateCoord, Qt::UniqueConnection);
 
@@ -198,6 +199,9 @@ void WbIndexedLineSet::updateCoord() {
 }
 
 void WbIndexedLineSet::updateCoordIndex() {
+  if (!sanitizeFields())
+    return;
+
   if (areWrenObjectsInitialized())
     buildWrenMesh();
 

--- a/src/webots/nodes/WbPlane.cpp
+++ b/src/webots/nodes/WbPlane.cpp
@@ -149,6 +149,8 @@ void WbPlane::createWrenObjects() {
   WbGeometry::createWrenObjects();
   WbGeometry::computeWrenRenderable();
 
+  sanitizeFields();
+
   const bool createOutlineMesh = isInBoundingObject();
 
   mWrenMesh = wr_static_mesh_unit_rectangle_new(createOutlineMesh);
@@ -222,7 +224,7 @@ void WbPlane::updateSize() {
 }
 
 void WbPlane::updateLineScale() {
-  if (!sanitizeFields() || !isAValidBoundingObject())
+  if (!isAValidBoundingObject())
     return;
 
   float offset = wr_config_get_line_scale() / LINE_SCALE_FACTOR;
@@ -236,9 +238,6 @@ void WbPlane::updateLineScale() {
 }
 
 void WbPlane::updateScale() {
-  if (!sanitizeFields())
-    return;
-
   // allow the bounding sphere to scale down
   float scaleY = 0.1f * std::min(mSize->value().x(), mSize->value().y());
 

--- a/src/webots/nodes/WbPointSet.cpp
+++ b/src/webots/nodes/WbPointSet.cpp
@@ -80,6 +80,7 @@ void WbPointSet::createWrenObjects() {
   wr_config_enable_point_size(true);
   updateCoord();
 
+  sanitizeFields();
   buildWrenMesh();
 
   emit wrenObjectsCreated();
@@ -121,9 +122,6 @@ void WbPointSet::buildWrenMesh() {
   mWrenMesh = NULL;
 
   WbGeometry::computeWrenRenderable();
-
-  if (!sanitizeFields())
-    return;
 
   float *coordsData = new float[coord()->pointSize() * 3];
   float *colorData = NULL;
@@ -174,6 +172,9 @@ int WbPointSet::computeCoordsAndColorData(float *coordsData, float *colorData) {
 }
 
 void WbPointSet::updateCoord() {
+  if (!sanitizeFields())
+    return;
+
   if (coord())
     connect(coord(), &WbCoordinate::fieldChanged, this, &WbPointSet::updateCoord, Qt::UniqueConnection);
 
@@ -187,6 +188,9 @@ void WbPointSet::updateCoord() {
 }
 
 void WbPointSet::updateColor() {
+  if (!sanitizeFields())
+    return;
+
   if (color())
     connect(color(), &WbCoordinate::fieldChanged, this, &WbPointSet::updateColor, Qt::UniqueConnection);
 

--- a/src/webots/nodes/WbSphere.cpp
+++ b/src/webots/nodes/WbSphere.cpp
@@ -83,6 +83,7 @@ void WbSphere::postFinalize() {
 void WbSphere::createWrenObjects() {
   WbGeometry::createWrenObjects();
 
+  sanitizeFields();
   buildWrenMesh();
 
   if (isInBoundingObject())
@@ -136,9 +137,6 @@ void WbSphere::buildWrenMesh() {
   wr_static_mesh_delete(mWrenMesh);
   mWrenMesh = NULL;
 
-  if (!sanitizeFields())
-    return;
-
   WbGeometry::computeWrenRenderable();
 
   mWrenMesh = wr_static_mesh_unit_sphere_new(mSubdivision->value());
@@ -185,7 +183,7 @@ void WbSphere::updateSubdivision() {
 }
 
 void WbSphere::updateLineScale() {
-  if (!isAValidBoundingObject() || !sanitizeFields())
+  if (!isAValidBoundingObject())
     return;
 
   float offset = wr_config_get_line_scale() / LINE_SCALE_FACTOR;
@@ -196,9 +194,6 @@ void WbSphere::updateLineScale() {
 }
 
 void WbSphere::updateScale() {
-  if (!sanitizeFields())
-    return;
-
   float scale[] = {static_cast<float>(mRadius->value()), static_cast<float>(mRadius->value()),
                    static_cast<float>(mRadius->value())};
   wr_transform_set_scale(wrenNode(), scale);


### PR DESCRIPTION
Address #431: change the way the geometry `sanitizeFields` function is called so that meshes are created after reset at load and the calls to `sanitizeFields` function on parameter change are reduced to 1.

This is done by
* moving `sanitizeFields` outside (just before) the `buildWrenMesh` function
* call `sanitizeFields` only when needed, i.e. at load or when a geometry field is changed