### PR TITLE
Fix Cylinder boundingObject representation

### DIFF
--- a/change_logs/ChangeLog.html
+++ b/change_logs/ChangeLog.html
@@ -17,6 +17,7 @@ Released on xx xxth, 2019
 <li><b>Enhancements</b></li>
 <ul>
 <li>Converted many PNG textures to JPEG to save disk space and network bandwidth.</li>
+<li>Improved boundingObject representation of Capsule and Cylinder geometries by setting a minimum subdivision value.</li>
 </ul>
 <li><b>Bug fixes</b></li>
 <ul>

--- a/change_logs/ChangeLog.html
+++ b/change_logs/ChangeLog.html
@@ -32,6 +32,7 @@ Released on xx xxth, 2019
 <li>Fixed availability of Muscle node in case of an Hinge2Joint ancestor (thanks to Florin).</li>
 <li>Fixed crash in streaming mode if a client connects while a world is loading.</li>
 <li>Fixed crash when using an 'infra-red' DistanceSensor node on a painted surface.</li>
+<li>Fixed mismatch between boundingObject outline and graphical representation of a Cylinder if the subdivision field is set to an odd value.</li>
 </ul>
 </ul>
 

--- a/src/webots/nodes/WbCapsule.cpp
+++ b/src/webots/nodes/WbCapsule.cpp
@@ -84,8 +84,13 @@ void WbCapsule::postFinalize() {
 void WbCapsule::createWrenObjects() {
   WbGeometry::createWrenObjects();
 
-  if (isInBoundingObject())
+  if (isInBoundingObject()) {
     connect(WbWrenRenderingContext::instance(), &WbWrenRenderingContext::lineScaleChanged, this, &WbCapsule::updateLineScale);
+
+    if (!isUseNode() && mSubdivision->value() < MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION)
+      // silently reset the subdivision on node initialization
+      mSubdivision->setValue(MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION);
+  }
 
   sanitizeFields();
   buildWrenMesh();
@@ -122,6 +127,13 @@ bool WbCapsule::areSizeFieldsVisibleAndNotRegenerator() const {
 bool WbCapsule::sanitizeFields() {
   if (WbFieldChecker::checkIntInRangeWithIncludedBounds(this, mSubdivision, 4, 1000, 4))
     return false;
+  if (!isUseNode() && isInBoundingObject() && mSubdivision->value() < MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION) {
+    warn(tr("'subdivision' value has no effect to physical 'boundingObject' geometry. "
+            "A minimum value of %2 is used for the representation.")
+           .arg(MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION));
+    mSubdivision->setValue(MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION);
+    return false;
+  }
 
   if (WbFieldChecker::checkDoubleIsPositive(this, mRadius, 1.0))
     return false;
@@ -160,9 +172,12 @@ void WbCapsule::buildWrenMesh() {
   setPickable(isPickable());
 
   const bool createOutlineMesh = isInBoundingObject();
+  const int subdivision = (createOutlineMesh && mSubdivision->value() < MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION) ?
+                            MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION :
+                            mSubdivision->value();
 
-  mWrenMesh = wr_static_mesh_capsule_new(mSubdivision->value(), mRadius->value(), mHeight->value(), mSide->isTrue(),
-                                         mTop->isTrue(), mBottom->isTrue(), createOutlineMesh);
+  mWrenMesh = wr_static_mesh_capsule_new(subdivision, mRadius->value(), mHeight->value(), mSide->isTrue(), mTop->isTrue(),
+                                         mBottom->isTrue(), createOutlineMesh);
 
   wr_renderable_set_mesh(mWrenRenderable, WR_MESH(mWrenMesh));
 }

--- a/src/webots/nodes/WbCapsule.cpp
+++ b/src/webots/nodes/WbCapsule.cpp
@@ -87,7 +87,7 @@ void WbCapsule::createWrenObjects() {
   if (isInBoundingObject()) {
     connect(WbWrenRenderingContext::instance(), &WbWrenRenderingContext::lineScaleChanged, this, &WbCapsule::updateLineScale);
 
-    if (!isUseNode() && mSubdivision->value() < MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION)
+    if (mSubdivision->value() < MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION && !WbNodeUtilities::hasAUseNodeAncestor(this))
       // silently reset the subdivision on node initialization
       mSubdivision->setValue(MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION);
   }
@@ -127,7 +127,8 @@ bool WbCapsule::areSizeFieldsVisibleAndNotRegenerator() const {
 bool WbCapsule::sanitizeFields() {
   if (WbFieldChecker::checkIntInRangeWithIncludedBounds(this, mSubdivision, 4, 1000, 4))
     return false;
-  if (!isUseNode() && isInBoundingObject() && mSubdivision->value() < MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION) {
+  if (mSubdivision->value() < MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION && isInBoundingObject() &&
+      !WbNodeUtilities::hasAUseNodeAncestor(this)) {
     warn(tr("'subdivision' value has no effect to physical 'boundingObject' geometry. "
             "A minimum value of %2 is used for the representation.")
            .arg(MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION));

--- a/src/webots/nodes/WbCylinder.cpp
+++ b/src/webots/nodes/WbCylinder.cpp
@@ -91,7 +91,7 @@ void WbCylinder::createWrenObjects() {
   if (isInBoundingObject()) {
     connect(WbWrenRenderingContext::instance(), &WbWrenRenderingContext::lineScaleChanged, this, &WbCylinder::updateLineScale);
 
-    if (!isUseNode() && mSubdivision->value() < MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION)
+    if (mSubdivision->value() < MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION && !WbNodeUtilities::hasAUseNodeAncestor(this))
       // silently reset the subdivision on node initialization
       mSubdivision->setValue(MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION);
   }
@@ -136,7 +136,8 @@ void WbCylinder::exportNodeFields(WbVrmlWriter &writer) const {
 bool WbCylinder::sanitizeFields() {
   if (WbFieldChecker::checkIntInRangeWithIncludedBounds(this, mSubdivision, 3, 1000, 3))
     return false;
-  if (!isUseNode() && isInBoundingObject() && mSubdivision->value() < MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION) {
+  if (mSubdivision->value() < MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION && isInBoundingObject() &&
+      !WbNodeUtilities::hasAUseNodeAncestor(this)) {
     warn(tr("'subdivision' value has no effect to physical 'boundingObject' geometry. "
             "A minimum value of %2 is used for the representation.")
            .arg(MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION));

--- a/src/webots/nodes/WbCylinder.cpp
+++ b/src/webots/nodes/WbCylinder.cpp
@@ -88,9 +88,13 @@ void WbCylinder::postFinalize() {
 void WbCylinder::createWrenObjects() {
   WbGeometry::createWrenObjects();
 
-  if (isInBoundingObject())
+  if (isInBoundingObject()) {
     connect(WbWrenRenderingContext::instance(), &WbWrenRenderingContext::lineScaleChanged, this, &WbCylinder::updateLineScale);
 
+    if (!isUseNode() && mSubdivision->value() < MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION)
+      // silently reset the subdivision on node initialization
+      mSubdivision->setValue(MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION);
+  }
   sanitizeFields();
   buildWrenMesh();
 
@@ -132,6 +136,13 @@ void WbCylinder::exportNodeFields(WbVrmlWriter &writer) const {
 bool WbCylinder::sanitizeFields() {
   if (WbFieldChecker::checkIntInRangeWithIncludedBounds(this, mSubdivision, 3, 1000, 3))
     return false;
+  if (!isUseNode() && isInBoundingObject() && mSubdivision->value() < MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION) {
+    warn(tr("'subdivision' value has no effect to physical 'boundingObject' geometry. "
+            "A minimum value of %2 is used for the representation.")
+           .arg(MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION));
+    mSubdivision->setValue(MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION);
+    return false;
+  }
 
   if (WbFieldChecker::checkDoubleIsPositive(this, mRadius, 1.0))
     return false;
@@ -152,11 +163,14 @@ void WbCylinder::buildWrenMesh() {
     return;
 
   const bool createOutlineMesh = isInBoundingObject();
+  const int subdivision = (createOutlineMesh && mSubdivision->value() < MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION) ?
+                            MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION :
+                            mSubdivision->value();
 
   WbGeometry::computeWrenRenderable();
 
-  mWrenMesh = wr_static_mesh_unit_cylinder_new(mSubdivision->value(), mSide->isTrue(), mTop->isTrue(), mBottom->isTrue(),
-                                               createOutlineMesh);
+  mWrenMesh =
+    wr_static_mesh_unit_cylinder_new(subdivision, mSide->isTrue(), mTop->isTrue(), mBottom->isTrue(), createOutlineMesh);
 
   // This must be done after WbGeometry::computeWrenRenderable() otherwise
   // the outline scaling is applied to the wrong WREN transform

--- a/src/webots/nodes/WbGeometry.hpp
+++ b/src/webots/nodes/WbGeometry.hpp
@@ -137,6 +137,10 @@ protected:
   WbGeometry(const WbNode &other);
   WbGeometry(const QString &modelName, WbTokenizer *tokenizer);
 
+  // for bounding object representation use a subdivision >= MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION
+  // so that it is clear for the user that the ODE object is a real rounded shape and not an approximation as the graphical mesh
+  const int MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION = 16;
+
   // Wren
   WrMaterial *mWrenMaterial;
   WrMaterial *mWrenEncodeDepthMaterial;

--- a/src/wren/StaticMesh.cpp
+++ b/src/wren/StaticMesh.cpp
@@ -388,8 +388,8 @@ namespace wren {
       mesh->estimateIndexCount(indexCount);
 
       for (int i = 0; i < subdivision + 1; ++i) {
-        double x = glm::sin(i * k);
-        double y = glm::cos(i * k);
+        const double x = glm::sin(i * k + glm::pi<float>());
+        const double y = glm::cos(i * k + glm::pi<float>());
 
         mesh->addCoord(glm::vec3(x, -h, y));
         mesh->addCoord(glm::vec3(x, h, y));


### PR DESCRIPTION
Address #411.

Tasks:
* [x] fix orientation of Cylinder outline mesh
* [x] set minimum subdivision (16) value for boundingObject Cylinder and Capsule
    -> make it clear that the ODE shape will be a real cylinder even if the subdivision value used for the graphical mesh is low