### PR TITLE
Document RosInertialUnit Axes Switch

### DIFF
--- a/projects/default/controllers/ros/RosInertialUnit.cpp
+++ b/projects/default/controllers/ros/RosInertialUnit.cpp
@@ -32,6 +32,8 @@ void RosInertialUnit::publishValue(ros::Publisher publisher) {
   value.header.stamp = ros::Time::now();
   value.header.frame_id = mRos->name() + '/' + RosDevice::fixedDeviceName();
 
+  // switch roll and pitch axes because the Webots and ROS coordinate systems are not equivalent
+  // https://stackoverflow.com/questions/56074321/quaternion-calculation-in-rosinertialunit-cpp-of-webots-ros-default-controller?answertab=oldest#tab-top
   double halfYaw = mInertialUnit->getRollPitchYaw()[1] * 0.5;
   double halfPitch = mInertialUnit->getRollPitchYaw()[0] * 0.5;
   double halfRoll = mInertialUnit->getRollPitchYaw()[2] * 0.5;


### PR DESCRIPTION
Since it took me quite some time to find the answer to https://stackoverflow.com/questions/56074321/quaternion-calculation-in-rosinertialunit-cpp-of-webots-ros-default-controller I think it is good to document it.