### PR TITLE
Improve WbFieldChecker functions names

### DIFF
--- a/src/webots/nodes/WbAbstractCamera.cpp
+++ b/src/webots/nodes/WbAbstractCamera.cpp
@@ -574,7 +574,7 @@ void WbAbstractCamera::updateLens() {
 }
 
 void WbAbstractCamera::updateFieldOfView() {
-  if (WbFieldChecker::checkDoubleIsPositive(this, mFieldOfView, 0.7854))
+  if (WbFieldChecker::resetDoubleIfNonPositive(this, mFieldOfView, 0.7854))
     return;
   if (!mSpherical->value() && fieldOfView() > M_PI) {
     warn(tr("Invalid 'fieldOfView' changed to 0.7854. The field of view is limited to pi if the 'spherical' field is FALSE."));
@@ -614,7 +614,7 @@ void WbAbstractCamera::updateAntiAliasing() {
 }
 
 void WbAbstractCamera::updateMotionBlur() {
-  if (!mMotionBlur || WbFieldChecker::checkDoubleIsNonNegative(this, mMotionBlur, 0.0))
+  if (!mMotionBlur || WbFieldChecker::resetDoubleIfNegative(this, mMotionBlur, 0.0))
     return;
 
   if (hasBeenSetup())
@@ -622,7 +622,7 @@ void WbAbstractCamera::updateMotionBlur() {
 }
 
 void WbAbstractCamera::updateNoise() {
-  if (WbFieldChecker::checkDoubleIsNonNegative(this, mNoise, 0.0))
+  if (WbFieldChecker::resetDoubleIfNegative(this, mNoise, 0.0))
     return;
 
   if (hasBeenSetup())

--- a/src/webots/nodes/WbAccelerometer.cpp
+++ b/src/webots/nodes/WbAccelerometer.cpp
@@ -83,7 +83,7 @@ void WbAccelerometer::updateLookupTable() {
 }
 
 void WbAccelerometer::updateResolution() {
-  WbFieldChecker::checkDoubleIsPositiveOrDisabled(this, mResolution, -1.0, -1.0);
+  WbFieldChecker::resetDoubleIfNonPositiveAndNotDisabled(this, mResolution, -1.0, -1.0);
 }
 
 void WbAccelerometer::handleMessage(QDataStream &stream) {

--- a/src/webots/nodes/WbBackground.cpp
+++ b/src/webots/nodes/WbBackground.cpp
@@ -253,7 +253,7 @@ void WbBackground::destroySkyBox() {
 }
 
 void WbBackground::updateColor() {
-  if (WbFieldChecker::checkMultipleColorIsValid(this, mSkyColor))
+  if (WbFieldChecker::resetMultipleColorIfInvalid(this, mSkyColor))
     return;
 
   if (areWrenObjectsInitialized())

--- a/src/webots/nodes/WbBox.cpp
+++ b/src/webots/nodes/WbBox.cpp
@@ -135,7 +135,7 @@ void WbBox::rescale(const WbVector3 &scale) {
 }
 
 bool WbBox::sanitizeFields() {
-  if (WbFieldChecker::checkVector3IsPositive(this, mSize, WbVector3(1.0, 1.0, 1.0)))
+  if (WbFieldChecker::resetVector3IfNonPositive(this, mSize, WbVector3(1.0, 1.0, 1.0)))
     return false;
 
   return true;

--- a/src/webots/nodes/WbCamera.cpp
+++ b/src/webots/nodes/WbCamera.cpp
@@ -803,7 +803,7 @@ void WbCamera::updateLensFlare() {
 }
 
 void WbCamera::updateNear() {
-  if (WbFieldChecker::checkDoubleIsPositive(this, mNear, 0.01))
+  if (WbFieldChecker::resetDoubleIfNonPositive(this, mNear, 0.01))
     return;
 
   mNeedToConfigure = true;
@@ -824,7 +824,7 @@ void WbCamera::updateNear() {
 }
 
 void WbCamera::updateFar() {
-  if (WbFieldChecker::checkDoubleIsNonNegative(this, mFar, 0.0))
+  if (WbFieldChecker::resetDoubleIfNegative(this, mFar, 0.0))
     return;
 
   if (mFar->value() > 0.0 and mFar->value() < mNear->value()) {
@@ -841,7 +841,7 @@ void WbCamera::updateFar() {
 }
 
 void WbCamera::updateExposure() {
-  if (WbFieldChecker::checkDoubleIsNonNegative(this, mExposure, 1.0))
+  if (WbFieldChecker::resetDoubleIfNegative(this, mExposure, 1.0))
     return;
 
   if (mWrenCamera)

--- a/src/webots/nodes/WbCapsule.cpp
+++ b/src/webots/nodes/WbCapsule.cpp
@@ -125,7 +125,7 @@ bool WbCapsule::areSizeFieldsVisibleAndNotRegenerator() const {
 }
 
 bool WbCapsule::sanitizeFields() {
-  if (WbFieldChecker::checkIntInRangeWithIncludedBounds(this, mSubdivision, 4, 1000, 4))
+  if (WbFieldChecker::resetIntIfNotInRangeWithIncludedBounds(this, mSubdivision, 4, 1000, 4))
     return false;
   if (mSubdivision->value() < MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION && isInBoundingObject() &&
       !WbNodeUtilities::hasAUseNodeAncestor(this)) {
@@ -136,10 +136,10 @@ bool WbCapsule::sanitizeFields() {
     return false;
   }
 
-  if (WbFieldChecker::checkDoubleIsPositive(this, mRadius, 1.0))
+  if (WbFieldChecker::resetDoubleIfNonPositive(this, mRadius, 1.0))
     return false;
 
-  if (WbFieldChecker::checkDoubleIsPositive(this, mHeight, 1.0))
+  if (WbFieldChecker::resetDoubleIfNonPositive(this, mHeight, 1.0))
     return false;
 
   return true;

--- a/src/webots/nodes/WbColor.cpp
+++ b/src/webots/nodes/WbColor.cpp
@@ -49,7 +49,7 @@ void WbColor::postFinalize() {
 }
 
 void WbColor::updateColor() {
-  if (WbFieldChecker::checkMultipleColorIsValid(this, mColor))
+  if (WbFieldChecker::resetMultipleColorIfInvalid(this, mColor))
     return;
   emit changed();
 }

--- a/src/webots/nodes/WbCompass.cpp
+++ b/src/webots/nodes/WbCompass.cpp
@@ -82,7 +82,7 @@ void WbCompass::updateLookupTable() {
 }
 
 void WbCompass::updateResolution() {
-  WbFieldChecker::checkDoubleIsPositiveOrDisabled(this, mResolution, -1.0, -1.0);
+  WbFieldChecker::resetDoubleIfNonPositiveAndNotDisabled(this, mResolution, -1.0, -1.0);
 }
 
 void WbCompass::handleMessage(QDataStream &stream) {

--- a/src/webots/nodes/WbCone.cpp
+++ b/src/webots/nodes/WbCone.cpp
@@ -114,13 +114,13 @@ bool WbCone::sanitizeFields() {
   if (isInBoundingObject())
     return false;
 
-  if (WbFieldChecker::checkIntInRangeWithIncludedBounds(this, mSubdivision, 3, 1000, 3))
+  if (WbFieldChecker::resetIntIfNotInRangeWithIncludedBounds(this, mSubdivision, 3, 1000, 3))
     return false;
 
-  if (WbFieldChecker::checkDoubleIsPositive(this, mBottomRadius, 1.0))
+  if (WbFieldChecker::resetDoubleIfNonPositive(this, mBottomRadius, 1.0))
     return false;
 
-  if (WbFieldChecker::checkDoubleIsPositive(this, mHeight, 1.0))
+  if (WbFieldChecker::resetDoubleIfNonPositive(this, mHeight, 1.0))
     return false;
 
   return true;

--- a/src/webots/nodes/WbContactProperties.cpp
+++ b/src/webots/nodes/WbContactProperties.cpp
@@ -113,7 +113,7 @@ void WbContactProperties::updateFrictionRotation() {
 }
 
 void WbContactProperties::updateBounce() {
-  if (WbFieldChecker::checkDoubleInRangeWithIncludedBounds(this, mBounce, 0.0, 1.0, 0.5))
+  if (WbFieldChecker::resetDoubleIfNotInRangeWithIncludedBounds(this, mBounce, 0.0, 1.0, 0.5))
     return;
 
   if (areOdeObjectsCreated())
@@ -123,7 +123,7 @@ void WbContactProperties::updateBounce() {
 }
 
 void WbContactProperties::updateBounceVelocity() {
-  if (WbFieldChecker::checkDoubleIsNonNegative(this, mBounceVelocity, 0.01))
+  if (WbFieldChecker::resetDoubleIfNegative(this, mBounceVelocity, 0.01))
     return;
 
   if (areOdeObjectsCreated())
@@ -146,7 +146,7 @@ void WbContactProperties::updateForceDependentSlip() {
 }
 
 void WbContactProperties::updateSoftCfm() {
-  if (WbFieldChecker::checkDoubleIsNonNegative(this, mSoftCfm, 0.001))
+  if (WbFieldChecker::resetDoubleIfNegative(this, mSoftCfm, 0.001))
     return;
   if (areOdeObjectsCreated())
     emit valuesChanged();
@@ -155,7 +155,7 @@ void WbContactProperties::updateSoftCfm() {
 }
 
 void WbContactProperties::updateSoftErp() {
-  if (WbFieldChecker::checkDoubleInRangeWithIncludedBounds(this, mSoftErp, 0.0, 1.0, 0.2))
+  if (WbFieldChecker::resetDoubleIfNotInRangeWithIncludedBounds(this, mSoftErp, 0.0, 1.0, 0.2))
     return;
 
   if (areOdeObjectsCreated())

--- a/src/webots/nodes/WbCylinder.cpp
+++ b/src/webots/nodes/WbCylinder.cpp
@@ -134,7 +134,7 @@ void WbCylinder::exportNodeFields(WbVrmlWriter &writer) const {
 }
 
 bool WbCylinder::sanitizeFields() {
-  if (WbFieldChecker::checkIntInRangeWithIncludedBounds(this, mSubdivision, 3, 1000, 3))
+  if (WbFieldChecker::resetIntIfNotInRangeWithIncludedBounds(this, mSubdivision, 3, 1000, 3))
     return false;
   if (mSubdivision->value() < MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION && isInBoundingObject() &&
       !WbNodeUtilities::hasAUseNodeAncestor(this)) {
@@ -145,10 +145,10 @@ bool WbCylinder::sanitizeFields() {
     return false;
   }
 
-  if (WbFieldChecker::checkDoubleIsPositive(this, mRadius, 1.0))
+  if (WbFieldChecker::resetDoubleIfNonPositive(this, mRadius, 1.0))
     return false;
 
-  if (WbFieldChecker::checkDoubleIsPositive(this, mHeight, 1.0))
+  if (WbFieldChecker::resetDoubleIfNonPositive(this, mHeight, 1.0))
     return false;
 
   return true;

--- a/src/webots/nodes/WbDistanceSensor.cpp
+++ b/src/webots/nodes/WbDistanceSensor.cpp
@@ -261,13 +261,13 @@ void WbDistanceSensor::updateRaySetup() {
     mRayType = SONAR;
 
   // correct invalid input values
-  if (WbFieldChecker::checkDoubleIsNonNegative(this, mAperture, -mAperture->value()))
+  if (WbFieldChecker::resetDoubleIfNegative(this, mAperture, -mAperture->value()))
     return;  // in order to avoiding passing twice in this function
-  if (WbFieldChecker::checkIntIsGreaterOrEqual(this, mNumberOfRays, 1, 1))
+  if (WbFieldChecker::resetIntIfLess(this, mNumberOfRays, 1, 1))
     return;  // in order to avoiding passing twice in this function
-  if (WbFieldChecker::checkDoubleIsPositive(this, mGaussianWidth, 1.0))
+  if (WbFieldChecker::resetDoubleIfNonPositive(this, mGaussianWidth, 1.0))
     return;  // in order to avoiding passing twice in this function
-  if (WbFieldChecker::checkDoubleIsPositiveOrDisabled(this, mResolution, -1, -1))
+  if (WbFieldChecker::resetDoubleIfNonPositiveAndNotDisabled(this, mResolution, -1, -1))
     return;  // in order to avoiding passing twice in this function
   if (mRayType == LASER && mNumberOfRays->value() > 1) {
     warn(tr("'type' \"laser\" must have one single ray."));

--- a/src/webots/nodes/WbElevationGrid.cpp
+++ b/src/webots/nodes/WbElevationGrid.cpp
@@ -198,19 +198,19 @@ void WbElevationGrid::rescale(const WbVector3 &scale) {
 }
 
 bool WbElevationGrid::sanitizeFields() {
-  if (WbFieldChecker::checkDoubleIsNonNegative(this, mThickness, 0.0))
+  if (WbFieldChecker::resetDoubleIfNegative(this, mThickness, 0.0))
     return false;
 
-  if (WbFieldChecker::checkIntIsNonNegative(this, mXDimension, 0))
+  if (WbFieldChecker::resetIntIfNegative(this, mXDimension, 0))
     return false;
 
-  if (WbFieldChecker::checkDoubleIsPositive(this, mXSpacing, 1.0))
+  if (WbFieldChecker::resetDoubleIfNonPositive(this, mXSpacing, 1.0))
     return false;
 
-  if (WbFieldChecker::checkIntIsNonNegative(this, mZDimension, 0))
+  if (WbFieldChecker::resetIntIfNegative(this, mZDimension, 0))
     return false;
 
-  if (WbFieldChecker::checkDoubleIsPositive(this, mZSpacing, 1.0))
+  if (WbFieldChecker::resetDoubleIfNonPositive(this, mZSpacing, 1.0))
     return false;
 
   checkHeight();

--- a/src/webots/nodes/WbEmitter.cpp
+++ b/src/webots/nodes/WbEmitter.cpp
@@ -86,17 +86,17 @@ void WbEmitter::updateTransmissionSetup() {
     mMediumType = WbDataPacket::RADIO;
   }
 
-  WbFieldChecker::checkDoubleIsInRangeWithIncludedBoundsOrDisabled(this, mAperture, 0, 2 * M_PI, -1, -1);
-  WbFieldChecker::checkDoubleIsPositiveOrDisabled(this, mMaxRange, -1, -1);
-  WbFieldChecker::checkIntIsGreaterOrEqual(this, mByteSize, 8, 8);
+  WbFieldChecker::resetDoubleIfNotInRangeWithIncludedBoundsAndNotDisabled(this, mAperture, 0, 2 * M_PI, -1, -1);
+  WbFieldChecker::resetDoubleIfNonPositiveAndNotDisabled(this, mMaxRange, -1, -1);
+  WbFieldChecker::resetIntIfLess(this, mByteSize, 8, 8);
 }
 
 void WbEmitter::updateBufferSize() {
-  WbFieldChecker::checkIntIsPositiveOrDisabled(this, mBufferSize, -1, -1);
+  WbFieldChecker::resetIntIfNonPositiveAndNotDisabled(this, mBufferSize, -1, -1);
   mNeedToSetBufferSize = true;
 }
 void WbEmitter::updateRange() {
-  WbFieldChecker::checkDoubleIsPositiveOrDisabled(this, mRange, -1, -1);
+  WbFieldChecker::resetDoubleIfNonPositiveAndNotDisabled(this, mRange, -1, -1);
   if (mMaxRange->value() != -1.0 && (mRange->value() > mMaxRange->value() || mRange->value() == -1.0)) {
     warn(tr("'range' must be less than or equal to 'maxRange'."));
     mRange->setValue(mMaxRange->value());

--- a/src/webots/nodes/WbFocus.cpp
+++ b/src/webots/nodes/WbFocus.cpp
@@ -57,19 +57,19 @@ void WbFocus::postFinalize() {
 }
 
 void WbFocus::updateFocalDistance() {
-  if (WbFieldChecker::checkDoubleIsNonNegative(this, mFocalDistance, 0.0))
+  if (WbFieldChecker::resetDoubleIfNegative(this, mFocalDistance, 0.0))
     return;
   emit focusSettingsChanged();
 }
 
 void WbFocus::updateFocalLength() {
-  if (WbFieldChecker::checkDoubleIsNonNegative(this, mFocalLength, 0.0))
+  if (WbFieldChecker::resetDoubleIfNegative(this, mFocalLength, 0.0))
     return;
   emit focusSettingsChanged();
 }
 
 void WbFocus::updateMinFocalDistance() {
-  if (WbFieldChecker::checkDoubleIsNonNegative(this, mMinFocalDistance, 0.0))
+  if (WbFieldChecker::resetDoubleIfNegative(this, mMinFocalDistance, 0.0))
     return;
   if (mMinFocalDistance->value() > mMaxFocalDistance->value()) {
     warn(tr("Invalid 'minFocalDistance' changed to %1. The value should be smaller or equal to 'maxFocalDistance'.")

--- a/src/webots/nodes/WbFog.cpp
+++ b/src/webots/nodes/WbFog.cpp
@@ -106,7 +106,7 @@ void WbFog::createWrenObjects() {
 }
 
 void WbFog::updateColor() {
-  if (WbFieldChecker::checkColorIsValid(this, mColor))
+  if (WbFieldChecker::resetColorIfInvalid(this, mColor))
     return;
 
   if (areWrenObjectsInitialized())
@@ -132,7 +132,7 @@ void WbFog::updateFogType() {
 }
 
 void WbFog::updateVisibilityRange() {
-  if (WbFieldChecker::checkDoubleIsNonNegative(this, mVisibilityRange, 0.0))
+  if (WbFieldChecker::resetDoubleIfNegative(this, mVisibilityRange, 0.0))
     return;
 
   if (areWrenObjectsInitialized())

--- a/src/webots/nodes/WbGps.cpp
+++ b/src/webots/nodes/WbGps.cpp
@@ -221,19 +221,19 @@ void WbGps::postFinalize() {
 }
 
 void WbGps::updateResolution() {
-  WbFieldChecker::checkDoubleIsPositiveOrDisabled(this, mResolution, -1.0, -1.0);
+  WbFieldChecker::resetDoubleIfNonPositiveAndNotDisabled(this, mResolution, -1.0, -1.0);
 }
 
 void WbGps::updateSpeedNoise() {
-  WbFieldChecker::checkDoubleIsNonNegative(this, mSpeedNoise, 0.0);
+  WbFieldChecker::resetDoubleIfNegative(this, mSpeedNoise, 0.0);
 }
 
 void WbGps::updateSpeedResolution() {
-  WbFieldChecker::checkDoubleIsPositiveOrDisabled(this, mSpeedResolution, -1.0, -1.0);
+  WbFieldChecker::resetDoubleIfNonPositiveAndNotDisabled(this, mSpeedResolution, -1.0, -1.0);
 }
 
 void WbGps::updateCorrelation() {
-  WbFieldChecker::checkDoubleInRangeWithIncludedBounds(this, mNoiseCorrelation, 0.0, 1.0, 0.0);
+  WbFieldChecker::resetDoubleIfNotInRangeWithIncludedBounds(this, mNoiseCorrelation, 0.0, 1.0, 0.0);
 }
 
 void WbGps::updateCoordinateSystem() {

--- a/src/webots/nodes/WbGyro.cpp
+++ b/src/webots/nodes/WbGyro.cpp
@@ -83,7 +83,7 @@ void WbGyro::updateLookupTable() {
 }
 
 void WbGyro::updateResolution() {
-  WbFieldChecker::checkDoubleIsPositiveOrDisabled(this, mResolution, -1.0, -1.0);
+  WbFieldChecker::resetDoubleIfNonPositiveAndNotDisabled(this, mResolution, -1.0, -1.0);
 }
 
 void WbGyro::handleMessage(QDataStream &stream) {

--- a/src/webots/nodes/WbImageTexture.cpp
+++ b/src/webots/nodes/WbImageTexture.cpp
@@ -204,7 +204,7 @@ void WbImageTexture::updateRepeatT() {
 }
 
 void WbImageTexture::updateFiltering() {
-  if (WbFieldChecker::checkIntIsNonNegative(this, mFiltering, 0))
+  if (WbFieldChecker::resetIntIfNegative(this, mFiltering, 0))
     return;
 
   int maxHardwareAfLevel = wr_gl_state_max_texture_anisotropy();

--- a/src/webots/nodes/WbIndexedFaceSet.cpp
+++ b/src/webots/nodes/WbIndexedFaceSet.cpp
@@ -85,7 +85,7 @@ void WbIndexedFaceSet::preFinalize() {
 
   WbGeometry::preFinalize();
 
-  WbFieldChecker::checkDoubleIsNonNegative(this, mCreaseAngle, 0.0);
+  WbFieldChecker::resetDoubleIfNegative(this, mCreaseAngle, 0.0);
 
   mMeshKey.set(this);
   WbTriangleMeshCache::useTriangleMesh(this);
@@ -296,7 +296,7 @@ void WbIndexedFaceSet::updateTexCoordIndex() {
 }
 
 void WbIndexedFaceSet::updateCreaseAngle() {
-  if (WbFieldChecker::checkDoubleIsNonNegative(this, mCreaseAngle, 0.0))
+  if (WbFieldChecker::resetDoubleIfNegative(this, mCreaseAngle, 0.0))
     return;
 
   buildWrenMesh(true);

--- a/src/webots/nodes/WbInertialUnit.cpp
+++ b/src/webots/nodes/WbInertialUnit.cpp
@@ -81,7 +81,7 @@ void WbInertialUnit::updateLookupTable() {
 }
 
 void WbInertialUnit::updateResolution() {
-  WbFieldChecker::checkDoubleIsPositiveOrDisabled(this, mResolution, -1.0, -1.0);
+  WbFieldChecker::resetDoubleIfNonPositiveAndNotDisabled(this, mResolution, -1.0, -1.0);
 }
 
 void WbInertialUnit::handleMessage(QDataStream &stream) {

--- a/src/webots/nodes/WbLensFlare.cpp
+++ b/src/webots/nodes/WbLensFlare.cpp
@@ -94,7 +94,7 @@ void WbLensFlare::detachFromViewport() {
 }
 
 void WbLensFlare::updateTransparency() {
-  if (WbFieldChecker::checkDoubleInRangeWithIncludedBounds(this, mTransparency, 0.0, 1.0, 0.5))
+  if (WbFieldChecker::resetDoubleIfNotInRangeWithIncludedBounds(this, mTransparency, 0.0, 1.0, 0.5))
     return;
 
   QMapIterator<WrViewport *, WbWrenLensFlare *> it(mWrenLensFlares);
@@ -129,7 +129,7 @@ void WbLensFlare::updateDispersal() {
 }
 
 void WbLensFlare::updateHaloWidth() {
-  if (WbFieldChecker::checkDoubleIsPositive(this, mHaloWidth, 0.5))
+  if (WbFieldChecker::resetDoubleIfNonPositive(this, mHaloWidth, 0.5))
     return;
 
   QMapIterator<WrViewport *, WbWrenLensFlare *> it(mWrenLensFlares);
@@ -148,7 +148,7 @@ void WbLensFlare::updateChromaDistortion() {
 }
 
 void WbLensFlare::updateSamples() {
-  if (WbFieldChecker::checkIntIsNonNegative(this, mSamples, 1))
+  if (WbFieldChecker::resetIntIfNegative(this, mSamples, 1))
     return;
 
   QMapIterator<WrViewport *, WbWrenLensFlare *> it(mWrenLensFlares);
@@ -159,7 +159,7 @@ void WbLensFlare::updateSamples() {
 }
 
 void WbLensFlare::updateBlur() {
-  if (WbFieldChecker::checkIntIsNonNegative(this, mBlurIterations, 2))
+  if (WbFieldChecker::resetIntIfNegative(this, mBlurIterations, 2))
     return;
 
   QMapIterator<WrViewport *, WbWrenLensFlare *> it(mWrenLensFlares);

--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -594,7 +594,7 @@ double WbLidar::actualFieldOfView() const {
 /////////////////////
 
 void WbLidar::updateNear() {
-  if (WbFieldChecker::checkDoubleIsPositive(this, mNear, 0.01))
+  if (WbFieldChecker::resetDoubleIfNonPositive(this, mNear, 0.01))
     return;
 
   if (mNear->value() > mMinRange->value()) {
@@ -608,7 +608,7 @@ void WbLidar::updateNear() {
 }
 
 void WbLidar::updateMinRange() {
-  if (WbFieldChecker::checkDoubleIsPositive(this, mMinRange, 0.01))
+  if (WbFieldChecker::resetDoubleIfNonPositive(this, mMinRange, 0.01))
     return;
 
   if (mMinRange->value() < mNear->value()) {
@@ -656,7 +656,7 @@ void WbLidar::updateFieldOfView() {
 }
 
 void WbLidar::updateResolution() {
-  if (WbFieldChecker::checkDoubleIsPositiveOrDisabled(this, mResolution, -1.0, -1.0))
+  if (WbFieldChecker::resetDoubleIfNonPositiveAndNotDisabled(this, mResolution, -1.0, -1.0))
     return;
 
   if (hasBeenSetup())
@@ -682,7 +682,7 @@ void WbLidar::updateType() {
 }
 
 void WbLidar::updateMinFrequency() {
-  WbFieldChecker::checkDoubleIsPositive(this, mMinFrequency, 0.01);
+  WbFieldChecker::resetDoubleIfNonPositive(this, mMinFrequency, 0.01);
   if (mMinFrequency->value() > mMaxFrequency->value()) {
     warn(tr("'minFrequency' should be smaller or equal to 'maxFrequency'."));
     mMinFrequency->setValue(mMaxFrequency->value());
@@ -692,7 +692,7 @@ void WbLidar::updateMinFrequency() {
 }
 
 void WbLidar::updateMaxFrequency() {
-  WbFieldChecker::checkDoubleIsPositive(this, mMaxFrequency, mMinFrequency->value());
+  WbFieldChecker::resetDoubleIfNonPositive(this, mMaxFrequency, mMinFrequency->value());
   if (mMaxFrequency->value() < mMinFrequency->value()) {
     warn(tr("'maxFrequency' should be bigger or equal to 'minFrequency'."));
     mMaxFrequency->setValue(mMinFrequency->value());
@@ -702,7 +702,7 @@ void WbLidar::updateMaxFrequency() {
 }
 
 void WbLidar::updateDefaultFrequency() {
-  WbFieldChecker::checkDoubleIsPositive(this, mDefaultFrequency, mMinFrequency->value());
+  WbFieldChecker::resetDoubleIfNonPositive(this, mDefaultFrequency, mMinFrequency->value());
   if (mDefaultFrequency->value() < mMinFrequency->value()) {
     warn(tr("'defaultFrequency' should be bigger or equal to 'minFrequency'."));
     mDefaultFrequency->setValue(mMinFrequency->value());
@@ -715,7 +715,7 @@ void WbLidar::updateDefaultFrequency() {
 }
 
 void WbLidar::updateHorizontalResolution() {
-  WbFieldChecker::checkIntIsPositive(this, mHorizontalResolution, 1);
+  WbFieldChecker::resetIntIfNonPositive(this, mHorizontalResolution, 1);
 
   // make sure we have at least 1 pixel height per layer
   if (height() < actualNumberOfLayers()) {
@@ -741,8 +741,8 @@ void WbLidar::updateHorizontalResolution() {
 }
 
 void WbLidar::updateVerticalFieldOfView() {
-  WbFieldChecker::checkDoubleIsPositive(this, mVerticalFieldOfView, 0.1);
-  WbFieldChecker::checkDoubleIsLessOrEqual(this, mVerticalFieldOfView, M_PI, M_PI);
+  WbFieldChecker::resetDoubleIfNonPositive(this, mVerticalFieldOfView, 0.1);
+  WbFieldChecker::resetDoubleIfGreater(this, mVerticalFieldOfView, M_PI, M_PI);
 
   // make sure we have at least 1 pixel height per layer
   if (height() < actualNumberOfLayers()) {
@@ -769,7 +769,7 @@ void WbLidar::updateVerticalFieldOfView() {
 }
 
 void WbLidar::updateNumberOfLayers() {
-  WbFieldChecker::checkIntIsPositive(this, mNumberOfLayers, 1);
+  WbFieldChecker::resetIntIfNonPositive(this, mNumberOfLayers, 1);
 
   // make sure we have at least 1 pixel height per layer
   if (height() < actualNumberOfLayers()) {

--- a/src/webots/nodes/WbLight.cpp
+++ b/src/webots/nodes/WbLight.cpp
@@ -151,7 +151,7 @@ void WbLight::createWrenObjects() {
 }
 
 void WbLight::updateAmbientIntensity() {
-  if (WbFieldChecker::checkDoubleInRangeWithIncludedBounds(this, mAmbientIntensity, 0.0, 1.0,
+  if (WbFieldChecker::resetDoubleIfNotInRangeWithIncludedBounds(this, mAmbientIntensity, 0.0, 1.0,
                                                            mAmbientIntensity->value() > 1.0 ? 1.0 : 0.0))
     return;
 
@@ -160,7 +160,7 @@ void WbLight::updateAmbientIntensity() {
 }
 
 void WbLight::updateIntensity() {
-  if (WbFieldChecker::checkDoubleIsNonNegative(this, mIntensity, 1.0))
+  if (WbFieldChecker::resetDoubleIfNegative(this, mIntensity, 1.0))
     return;
 
   if (areWrenObjectsInitialized())
@@ -181,7 +181,7 @@ void WbLight::updateOn() {
 }
 
 void WbLight::updateColor() {
-  if (WbFieldChecker::checkColorIsValid(this, mColor))
+  if (WbFieldChecker::resetColorIfInvalid(this, mColor))
     return;
 
   if (areWrenObjectsInitialized())

--- a/src/webots/nodes/WbLight.cpp
+++ b/src/webots/nodes/WbLight.cpp
@@ -152,7 +152,7 @@ void WbLight::createWrenObjects() {
 
 void WbLight::updateAmbientIntensity() {
   if (WbFieldChecker::resetDoubleIfNotInRangeWithIncludedBounds(this, mAmbientIntensity, 0.0, 1.0,
-                                                           mAmbientIntensity->value() > 1.0 ? 1.0 : 0.0))
+                                                                mAmbientIntensity->value() > 1.0 ? 1.0 : 0.0))
     return;
 
   if (areWrenObjectsInitialized())

--- a/src/webots/nodes/WbLightSensor.cpp
+++ b/src/webots/nodes/WbLightSensor.cpp
@@ -202,7 +202,7 @@ void WbLightSensor::updateLookupTable() {
 }
 
 void WbLightSensor::updateResolution() {
-  WbFieldChecker::checkDoubleIsPositiveOrDisabled(this, mResolution, -1.0, -1.0);
+  WbFieldChecker::resetDoubleIfNonPositiveAndNotDisabled(this, mResolution, -1.0, -1.0);
 }
 
 void WbLightSensor::prePhysicsStep(double ms) {

--- a/src/webots/nodes/WbMaterial.cpp
+++ b/src/webots/nodes/WbMaterial.cpp
@@ -93,42 +93,42 @@ const WbRgb &WbMaterial::diffuseColor() const {
 }
 
 void WbMaterial::updateAmbientIntensity() {
-  if (WbFieldChecker::checkDoubleInRangeWithIncludedBounds(this, mAmbientIntensity, 0.0, 1.0, 0.5))
+  if (WbFieldChecker::resetDoubleIfNotInRangeWithIncludedBounds(this, mAmbientIntensity, 0.0, 1.0, 0.5))
     return;
   if (isPostFinalizedCalled())
     emit changed();
 }
 
 void WbMaterial::updateDiffuseColor() {
-  if (WbFieldChecker::checkColorIsValid(this, mDiffuseColor))
+  if (WbFieldChecker::resetColorIfInvalid(this, mDiffuseColor))
     return;
   if (isPostFinalizedCalled())
     emit changed();
 }
 
 void WbMaterial::updateEmissiveColor() {
-  if (WbFieldChecker::checkColorIsValid(this, mEmissiveColor))
+  if (WbFieldChecker::resetColorIfInvalid(this, mEmissiveColor))
     return;
   if (isPostFinalizedCalled())
     emit changed();
 }
 
 void WbMaterial::updateShininess() {
-  if (WbFieldChecker::checkDoubleInRangeWithIncludedBounds(this, mShininess, 0.0, 1.0, 0.5))
+  if (WbFieldChecker::resetDoubleIfNotInRangeWithIncludedBounds(this, mShininess, 0.0, 1.0, 0.5))
     return;
   if (isPostFinalizedCalled())
     emit changed();
 }
 
 void WbMaterial::updateSpecularColor() {
-  if (WbFieldChecker::checkColorIsValid(this, mSpecularColor))
+  if (WbFieldChecker::resetColorIfInvalid(this, mSpecularColor))
     return;
   if (isPostFinalizedCalled())
     emit changed();
 }
 
 void WbMaterial::updateTransparency() {
-  if (WbFieldChecker::checkDoubleInRangeWithIncludedBounds(this, mTransparency, 0.0, 1.0, 0.5))
+  if (WbFieldChecker::resetDoubleIfNotInRangeWithIncludedBounds(this, mTransparency, 0.0, 1.0, 0.5))
     return;
   if (isPostFinalizedCalled())
     emit changed();

--- a/src/webots/nodes/WbMotor.cpp
+++ b/src/webots/nodes/WbMotor.cpp
@@ -171,19 +171,19 @@ void WbMotor::updateMinAndMaxPosition() {
     p = parentJoint->parameters()->position();
 
   // current joint position should lie between min and max position
-  WbFieldChecker::checkDoubleIsGreaterOrEqual(this, mMaxPosition, p, p);
-  WbFieldChecker::checkDoubleIsLessOrEqual(this, mMinPosition, p, p);
+  WbFieldChecker::resetDoubleIfLess(this, mMaxPosition, p, p);
+  WbFieldChecker::resetDoubleIfGreater(this, mMinPosition, p, p);
 
   mNeedToConfigure = true;
 }
 
 void WbMotor::updateMaxForceOrTorque() {
-  WbFieldChecker::checkDoubleIsNonNegative(this, mMaxForceOrTorque, 10.0);
+  WbFieldChecker::resetDoubleIfNegative(this, mMaxForceOrTorque, 10.0);
   mNeedToConfigure = true;
 }
 
 void WbMotor::updateMaxVelocity() {
-  WbFieldChecker::checkDoubleIsNonNegative(this, mMaxVelocity, -mMaxVelocity->value());
+  WbFieldChecker::resetDoubleIfNegative(this, mMaxVelocity, -mMaxVelocity->value());
   mNeedToConfigure = true;
 }
 
@@ -228,7 +228,7 @@ void WbMotor::updateMuscles() {
 }
 
 void WbMotor::updateMaxAcceleration() {
-  WbFieldChecker::checkDoubleIsNonNegativeOrDisabled(this, mAcceleration, -1, -1);
+  WbFieldChecker::resetDoubleIfNegativeAndNotDisabled(this, mAcceleration, -1, -1);
   mNeedToConfigure = true;
 }
 

--- a/src/webots/nodes/WbMuscle.cpp
+++ b/src/webots/nodes/WbMuscle.cpp
@@ -145,7 +145,7 @@ void WbMuscle::updateRadius() {
     return;
   }
 
-  WbFieldChecker::checkDoubleIsPositive(this, mMaxRadius, 0.2);
+  WbFieldChecker::resetDoubleIfNonPositive(this, mMaxRadius, 0.2);
   mDirectionInverted = false;
   const WbNode *jointNode = motor->parent();
   const WbSliderJoint *slider = dynamic_cast<const WbSliderJoint *>(jointNode);

--- a/src/webots/nodes/WbPbrAppearance.cpp
+++ b/src/webots/nodes/WbPbrAppearance.cpp
@@ -390,14 +390,14 @@ void WbPbrAppearance::updateBaseColorMap() {
 }
 
 void WbPbrAppearance::updateTransparency() {
-  if (WbFieldChecker::checkDoubleInRangeWithIncludedBounds(this, mTransparency, 0.0, 1.0, 0.0))
+  if (WbFieldChecker::resetDoubleIfNotInRangeWithIncludedBounds(this, mTransparency, 0.0, 1.0, 0.0))
     return;
   if (isPostFinalizedCalled())
     emit changed();
 }
 
 void WbPbrAppearance::updateRoughness() {
-  if (WbFieldChecker::checkDoubleInRangeWithIncludedBounds(this, mRoughness, 0.0, 1.0, 0.0))
+  if (WbFieldChecker::resetDoubleIfNotInRangeWithIncludedBounds(this, mRoughness, 0.0, 1.0, 0.0))
     return;
   if (isPostFinalizedCalled())
     emit changed();
@@ -412,7 +412,7 @@ void WbPbrAppearance::updateRoughnessMap() {
 }
 
 void WbPbrAppearance::updateMetalness() {
-  if (WbFieldChecker::checkDoubleInRangeWithIncludedBounds(this, mMetalness, 0.0, 1.0, 0.0))
+  if (WbFieldChecker::resetDoubleIfNotInRangeWithIncludedBounds(this, mMetalness, 0.0, 1.0, 0.0))
     return;
   if (isPostFinalizedCalled())
     emit changed();
@@ -436,7 +436,7 @@ void WbPbrAppearance::updateEnvironmentMap() {
 }
 
 void WbPbrAppearance::updateIblStrength() {
-  if (WbFieldChecker::checkDoubleIsNonNegative(this, mIblStrength, 1.0))
+  if (WbFieldChecker::resetDoubleIfNegative(this, mIblStrength, 1.0))
     return;
   if (isPostFinalizedCalled())
     emit changed();
@@ -451,7 +451,7 @@ void WbPbrAppearance::updateNormalMap() {
 }
 
 void WbPbrAppearance::updateNormalMapFactor() {
-  if (WbFieldChecker::checkDoubleIsNonNegative(this, mNormalMapFactor, 1.0))
+  if (WbFieldChecker::resetDoubleIfNegative(this, mNormalMapFactor, 1.0))
     return;
   if (isPostFinalizedCalled())
     emit changed();
@@ -465,7 +465,7 @@ void WbPbrAppearance::updateOcclusionMap() {
 }
 
 void WbPbrAppearance::updateOcclusionMapStrength() {
-  if (WbFieldChecker::checkDoubleIsNonNegative(this, mOcclusionMapStrength, 1.0))
+  if (WbFieldChecker::resetDoubleIfNegative(this, mOcclusionMapStrength, 1.0))
     return;
   if (isPostFinalizedCalled())
     emit changed();

--- a/src/webots/nodes/WbPen.cpp
+++ b/src/webots/nodes/WbPen.cpp
@@ -79,7 +79,7 @@ WbPen::~WbPen() {
 void WbPen::preFinalize() {
   WbSolidDevice::preFinalize();
 
-  WbFieldChecker::checkAndClampDoubleInRangeWithIncludedBounds(this, mInkDensity, 0.0, 1.0);
+  WbFieldChecker::clampDoubleToRangeWithIncludedBounds(this, mInkDensity, 0.0, 1.0);
 }
 
 void WbPen::handleMessage(QDataStream &stream) {
@@ -101,7 +101,7 @@ void WbPen::handleMessage(QDataStream &stream) {
       unsigned char density = 0;
       stream >> (unsigned char &)density;
       mInkDensity->setValue((double)density / 255.0);
-      WbFieldChecker::checkAndClampDoubleInRangeWithIncludedBounds(this, mInkDensity, 0.0, 1.0);
+      WbFieldChecker::clampDoubleToRangeWithIncludedBounds(this, mInkDensity, 0.0, 1.0);
       return;
     }
     default:

--- a/src/webots/nodes/WbPhysics.cpp
+++ b/src/webots/nodes/WbPhysics.cpp
@@ -107,14 +107,14 @@ void WbPhysics::reset() {
 
 void WbPhysics::checkMass() {
   if (mDensity->value() <= 0.0)
-    WbFieldChecker::checkDoubleIsPositive(this, mMass, 1);
-  WbFieldChecker::checkDoubleIsPositiveOrDisabled(this, mMass, -1, -1);
+    WbFieldChecker::resetDoubleIfNonPositive(this, mMass, 1);
+  WbFieldChecker::resetDoubleIfNonPositiveAndNotDisabled(this, mMass, -1, -1);
 }
 
 void WbPhysics::checkDensity() {
   if (mMass->value() <= 0.0)
-    WbFieldChecker::checkDoubleIsPositive(this, mDensity, 1000);
-  WbFieldChecker::checkDoubleIsPositiveOrDisabled(this, mDensity, 1000, -1);
+    WbFieldChecker::resetDoubleIfNonPositive(this, mDensity, 1000);
+  WbFieldChecker::resetDoubleIfNonPositiveAndNotDisabled(this, mDensity, 1000, -1);
 }
 
 void WbPhysics::checkMassAndDensity() const {

--- a/src/webots/nodes/WbPlane.cpp
+++ b/src/webots/nodes/WbPlane.cpp
@@ -190,7 +190,7 @@ bool WbPlane::areSizeFieldsVisibleAndNotRegenerator() const {
 }
 
 bool WbPlane::sanitizeFields() {
-  if (WbFieldChecker::checkVector2IsPositive(this, mSize, WbVector2(1.0, 1.0)))
+  if (WbFieldChecker::resetVector2IfNonPositive(this, mSize, WbVector2(1.0, 1.0)))
     return false;
 
   return true;

--- a/src/webots/nodes/WbPointLight.cpp
+++ b/src/webots/nodes/WbPointLight.cpp
@@ -114,7 +114,7 @@ void WbPointLight::updateOptionalRendering(int option) {
 }
 
 void WbPointLight::updateAttenuation() {
-  if (WbFieldChecker::checkVector3IsNonNegative(this, mAttenuation, WbVector3()))
+  if (WbFieldChecker::resetVector3IfNegative(this, mAttenuation, WbVector3()))
     return;
 
   checkAmbientAndAttenuationExclusivity();
@@ -130,7 +130,7 @@ void WbPointLight::updateLocation() {
 }
 
 void WbPointLight::updateRadius() {
-  if (WbFieldChecker::checkDoubleIsNonNegative(this, mRadius, 0.0))
+  if (WbFieldChecker::resetDoubleIfNegative(this, mRadius, 0.0))
     return;
 
   if (areWrenObjectsInitialized())

--- a/src/webots/nodes/WbPositionSensor.cpp
+++ b/src/webots/nodes/WbPositionSensor.cpp
@@ -63,11 +63,11 @@ void WbPositionSensor::postFinalize() {
 }
 
 void WbPositionSensor::updateNoise() {
-  WbFieldChecker::checkDoubleIsNonNegative(this, mNoise, 0.0);
+  WbFieldChecker::resetDoubleIfNegative(this, mNoise, 0.0);
 }
 
 void WbPositionSensor::updateResolution() {
-  WbFieldChecker::checkDoubleIsPositiveOrDisabled(this, mResolution, -1.0, -1.0);
+  WbFieldChecker::resetDoubleIfNonPositiveAndNotDisabled(this, mResolution, -1.0, -1.0);
 }
 
 void WbPositionSensor::writeConfigure(QDataStream &stream) {

--- a/src/webots/nodes/WbRadar.cpp
+++ b/src/webots/nodes/WbRadar.cpp
@@ -165,7 +165,7 @@ void WbRadar::updateOptionalRendering(int option) {
 }
 
 void WbRadar::updateMinRange() {
-  WbFieldChecker::checkDoubleIsNonNegative(this, mMinRange, 0.0);
+  WbFieldChecker::resetDoubleIfNegative(this, mMinRange, 0.0);
   if (mMaxRange->value() <= mMinRange->value()) {
     if (mMaxRange->value() == 0.0) {
       double newMaxRange = mMinRange->value() + 1.0;
@@ -189,7 +189,7 @@ void WbRadar::updateMinRange() {
 }
 
 void WbRadar::updateMaxRange() {
-  WbFieldChecker::checkDoubleIsNonNegative(this, mMaxRange, mMinRange->value() + 1.0);
+  WbFieldChecker::resetDoubleIfNegative(this, mMaxRange, mMinRange->value() + 1.0);
 
   if (mMaxRange->value() <= mMinRange->value()) {
     double newMaxRange = mMinRange->value() + 1.0;
@@ -204,19 +204,19 @@ void WbRadar::updateMaxRange() {
 }
 
 void WbRadar::updateHorizontalFieldOfView() {
-  WbFieldChecker::checkDoubleInRangeWithExcludedBounds(this, mHorizontalFieldOfView, 0.0, 2 * M_PI, 0.78);
+  WbFieldChecker::resetDoubleIfNotInRangeWithExcludedBounds(this, mHorizontalFieldOfView, 0.0, 2 * M_PI, 0.78);
   if (areWrenObjectsInitialized())
     applyFrustumToWren();
 }
 
 void WbRadar::updateVerticalFieldOfView() {
-  WbFieldChecker::checkDoubleInRangeWithExcludedBounds(this, mVerticalFieldOfView, 0.0, M_PI_2, 0.1);
+  WbFieldChecker::resetDoubleIfNotInRangeWithExcludedBounds(this, mVerticalFieldOfView, 0.0, M_PI_2, 0.1);
   if (areWrenObjectsInitialized())
     applyFrustumToWren();
 }
 
 void WbRadar::updateMinAbsoluteRadialSpeed() {
-  WbFieldChecker::checkDoubleIsNonNegative(this, mMinAbsoluteRadialSpeed, 0.0);
+  WbFieldChecker::resetDoubleIfNegative(this, mMinAbsoluteRadialSpeed, 0.0);
 }
 
 void WbRadar::updateMinAndMaxRadialSpeed() {
@@ -236,27 +236,27 @@ void WbRadar::updateMinAndMaxRadialSpeed() {
 }
 
 void WbRadar::updateCellDistance() {
-  WbFieldChecker::checkDoubleIsNonNegative(this, mCellDistance, 0.0);
+  WbFieldChecker::resetDoubleIfNegative(this, mCellDistance, 0.0);
 }
 
 void WbRadar::updateCellSpeed() {
-  WbFieldChecker::checkDoubleIsNonNegative(this, mCellSpeed, 0.0);
+  WbFieldChecker::resetDoubleIfNegative(this, mCellSpeed, 0.0);
 }
 
 void WbRadar::updateRangeNoise() {
-  WbFieldChecker::checkDoubleIsNonNegative(this, mRangeNoise, 0.0);
+  WbFieldChecker::resetDoubleIfNegative(this, mRangeNoise, 0.0);
 }
 
 void WbRadar::updateSpeedNoise() {
-  WbFieldChecker::checkDoubleIsNonNegative(this, mSpeedNoise, 0.0);
+  WbFieldChecker::resetDoubleIfNegative(this, mSpeedNoise, 0.0);
 }
 
 void WbRadar::updateAngularNoise() {
-  WbFieldChecker::checkDoubleIsNonNegative(this, mAngularNoise, 0.0);
+  WbFieldChecker::resetDoubleIfNegative(this, mAngularNoise, 0.0);
 }
 
 void WbRadar::updateFrequency() {
-  WbFieldChecker::checkDoubleIsNonNegative(this, mFrequency, 24.0);
+  WbFieldChecker::resetDoubleIfNegative(this, mFrequency, 24.0);
   updateReceivedPowerFactor();
 }
 

--- a/src/webots/nodes/WbRangeFinder.cpp
+++ b/src/webots/nodes/WbRangeFinder.cpp
@@ -117,7 +117,7 @@ void WbRangeFinder::createWrenCamera() {
 /////////////////////
 
 void WbRangeFinder::updateNear() {
-  if (WbFieldChecker::checkDoubleIsPositive(this, mNear, 0.01))
+  if (WbFieldChecker::resetDoubleIfNonPositive(this, mNear, 0.01))
     return;
 
   if (mNear->value() > mMinRange->value()) {
@@ -133,7 +133,7 @@ void WbRangeFinder::updateNear() {
 }
 
 void WbRangeFinder::updateMinRange() {
-  if (WbFieldChecker::checkDoubleIsPositive(this, mMinRange, 0.01))
+  if (WbFieldChecker::resetDoubleIfNonPositive(this, mMinRange, 0.01))
     return;
 
   if (mMinRange->value() < mNear->value()) {
@@ -191,7 +191,7 @@ void WbRangeFinder::updateMaxRange() {
 }
 
 void WbRangeFinder::updateResolution() {
-  if (WbFieldChecker::checkDoubleIsPositiveOrDisabled(this, mResolution, -1.0, -1.0))
+  if (WbFieldChecker::resetDoubleIfNonPositiveAndNotDisabled(this, mResolution, -1.0, -1.0))
     return;
 
   if (hasBeenSetup())

--- a/src/webots/nodes/WbReceiver.cpp
+++ b/src/webots/nodes/WbReceiver.cpp
@@ -166,12 +166,12 @@ void WbReceiver::updateTransmissionSetup() {
     mMediumType = WbDataPacket::RADIO;
   }
 
-  WbFieldChecker::checkDoubleIsInRangeWithIncludedBoundsOrDisabled(this, mAperture, 0, 2 * M_PI, -1, -1);
-  WbFieldChecker::checkDoubleIsNonNegative(this, mSignalStrengthNoise, 0);
-  WbFieldChecker::checkDoubleIsNonNegative(this, mDirectionNoise, 0);
-  WbFieldChecker::checkIntIsPositiveOrDisabled(this, mBufferSize, -1, -1);
-  WbFieldChecker::checkIntIsPositiveOrDisabled(this, mBaudRate, -1, -1);
-  WbFieldChecker::checkIntIsGreaterOrEqual(this, mByteSize, 8, 8);
+  WbFieldChecker::resetDoubleIfNotInRangeWithIncludedBoundsAndNotDisabled(this, mAperture, 0, 2 * M_PI, -1, -1);
+  WbFieldChecker::resetDoubleIfNegative(this, mSignalStrengthNoise, 0);
+  WbFieldChecker::resetDoubleIfNegative(this, mDirectionNoise, 0);
+  WbFieldChecker::resetIntIfNonPositiveAndNotDisabled(this, mBufferSize, -1, -1);
+  WbFieldChecker::resetIntIfNonPositiveAndNotDisabled(this, mBaudRate, -1, -1);
+  WbFieldChecker::resetIntIfLess(this, mByteSize, 8, 8);
 
   mNeedToConfigure = true;
 }

--- a/src/webots/nodes/WbRecognition.cpp
+++ b/src/webots/nodes/WbRecognition.cpp
@@ -55,16 +55,16 @@ void WbRecognition::postFinalize() {
 }
 
 void WbRecognition::updateMaxRange() {
-  if (WbFieldChecker::checkDoubleIsPositive(this, mMaxRange, 100.0))
+  if (WbFieldChecker::resetDoubleIfNonPositive(this, mMaxRange, 100.0))
     return;
 }
 
 void WbRecognition::updateMaxObjects() {
-  if (WbFieldChecker::checkIntIsPositiveOrDisabled(this, mMaxObjects, -1, -1))
+  if (WbFieldChecker::resetIntIfNonPositiveAndNotDisabled(this, mMaxObjects, -1, -1))
     return;
 }
 
 void WbRecognition::updateFrameThickness() {
-  if (WbFieldChecker::checkIntIsNonNegative(this, mFrameThickness, 0))
+  if (WbFieldChecker::resetIntIfNegative(this, mFrameThickness, 0))
     return;
 }

--- a/src/webots/nodes/WbSphere.cpp
+++ b/src/webots/nodes/WbSphere.cpp
@@ -122,10 +122,10 @@ void WbSphere::exportNodeFields(WbVrmlWriter &writer) const {
 }
 
 bool WbSphere::sanitizeFields() {
-  if (WbFieldChecker::checkIntInRangeWithIncludedBounds(this, mSubdivision, 1, 6, 1))
+  if (WbFieldChecker::resetIntIfNotInRangeWithIncludedBounds(this, mSubdivision, 1, 6, 1))
     return false;
 
-  if (WbFieldChecker::checkDoubleIsPositive(this, mRadius, 1.0))
+  if (WbFieldChecker::resetDoubleIfNonPositive(this, mRadius, 1.0))
     return false;
 
   return true;

--- a/src/webots/nodes/WbSpotLight.cpp
+++ b/src/webots/nodes/WbSpotLight.cpp
@@ -124,7 +124,7 @@ void WbSpotLight::updateOptionalRendering(int option) {
 }
 
 void WbSpotLight::updateAttenuation() {
-  if (WbFieldChecker::checkVector3IsNonNegative(this, mAttenuation, WbVector3()))
+  if (WbFieldChecker::resetVector3IfNegative(this, mAttenuation, WbVector3()))
     return;
 
   checkAmbientAndAttenuationExclusivity();
@@ -140,7 +140,7 @@ void WbSpotLight::updateLocation() {
 }
 
 void WbSpotLight::updateRadius() {
-  if (WbFieldChecker::checkDoubleIsNonNegative(this, mRadius, 0.0))
+  if (WbFieldChecker::resetDoubleIfNegative(this, mRadius, 0.0))
     return;
 
   if (areWrenObjectsInitialized())
@@ -173,7 +173,7 @@ void WbSpotLight::updateDirection() {
 }
 
 void WbSpotLight::updateCutOffAngle() {
-  if (WbFieldChecker::checkDoubleInRangeWithIncludedBounds(this, mCutOffAngle, 0.0, M_PI_2, M_PI_2))
+  if (WbFieldChecker::resetDoubleIfNotInRangeWithIncludedBounds(this, mCutOffAngle, 0.0, M_PI_2, M_PI_2))
     return;
 
   if (mCutOffAngle->value() < mBeamWidth->value()) {
@@ -187,7 +187,7 @@ void WbSpotLight::updateCutOffAngle() {
 }
 
 void WbSpotLight::updateBeamWidth() {
-  if (WbFieldChecker::checkDoubleIsNonNegative(this, mBeamWidth, 0.0))
+  if (WbFieldChecker::resetDoubleIfNegative(this, mBeamWidth, 0.0))
     return;
   else if (mBeamWidth->value() > mCutOffAngle->value()) {
     warn(tr("Invalid 'beamWidth' changed to %1. The value should be less than or equal to 'cutOffAngle'.")

--- a/src/webots/nodes/WbTouchSensor.cpp
+++ b/src/webots/nodes/WbTouchSensor.cpp
@@ -106,7 +106,7 @@ void WbTouchSensor::updateType() {
 }
 
 void WbTouchSensor::updateResolution() {
-  WbFieldChecker::checkDoubleIsPositiveOrDisabled(this, mResolution, -1.0, -1.0);
+  WbFieldChecker::resetDoubleIfNonPositiveAndNotDisabled(this, mResolution, -1.0, -1.0);
 }
 
 void WbTouchSensor::handleMessage(QDataStream &stream) {

--- a/src/webots/nodes/WbTrackWheel.cpp
+++ b/src/webots/nodes/WbTrackWheel.cpp
@@ -72,7 +72,7 @@ void WbTrackWheel::updatePosition() {
 }
 
 void WbTrackWheel::updateRadius() {
-  if (WbFieldChecker::checkDoubleIsPositive(this, mRadius, 0.1) && isPostFinalizedCalled())
+  if (WbFieldChecker::resetDoubleIfNonPositive(this, mRadius, 0.1) && isPostFinalizedCalled())
     emit changed();
 }
 

--- a/src/webots/nodes/WbViewpoint.cpp
+++ b/src/webots/nodes/WbViewpoint.cpp
@@ -351,11 +351,11 @@ void WbViewpoint::updateLensFlare() {
 }
 
 void WbViewpoint::updateAmbientOcclusionRadius() {
-  WbFieldChecker::checkDoubleIsNonNegative(this, mAmbientOcclusionRadius, 2.0);
+  WbFieldChecker::resetDoubleIfNegative(this, mAmbientOcclusionRadius, 2.0);
 }
 
 void WbViewpoint::updateBloomThreshold() {
-  WbFieldChecker::checkDoubleIsNonNegativeOrDisabled(this, mBloomThreshold, 10.0, -1.0);
+  WbFieldChecker::resetDoubleIfNegativeAndNotDisabled(this, mBloomThreshold, 10.0, -1.0);
 }
 
 WbLensFlare *WbViewpoint::lensFlare() const {
@@ -560,7 +560,7 @@ void WbViewpoint::showCoordinateSystem(bool visible) {
 /////////////////////
 
 void WbViewpoint::updateFieldOfView() {
-  if (WbFieldChecker::checkDoubleInRangeWithExcludedBounds(this, mFieldOfView, 0.0, M_PI, M_PI_2))
+  if (WbFieldChecker::resetDoubleIfNotInRangeWithExcludedBounds(this, mFieldOfView, 0.0, M_PI, M_PI_2))
     return;
 
   updateFieldOfViewY();
@@ -586,7 +586,7 @@ void WbViewpoint::updatePosition() {
 }
 
 void WbViewpoint::updateNear() {
-  if (WbFieldChecker::checkDoubleIsPositive(this, mNear, 0.05))
+  if (WbFieldChecker::resetDoubleIfNonPositive(this, mNear, 0.05))
     return;
 
   if (mFar->value() > 0.0 and mFar->value() < mNear->value()) {
@@ -599,7 +599,7 @@ void WbViewpoint::updateNear() {
 }
 
 void WbViewpoint::updateFar() {
-  if (WbFieldChecker::checkDoubleIsNonNegative(this, mFar, 0.0))
+  if (WbFieldChecker::resetDoubleIfNegative(this, mFar, 0.0))
     return;
 
   if (mFar->value() > 0.0 and mFar->value() < mNear->value()) {
@@ -613,7 +613,7 @@ void WbViewpoint::updateFar() {
 }
 
 void WbViewpoint::updateExposure() {
-  if (WbFieldChecker::checkDoubleIsNonNegative(this, mExposure, 1.0))
+  if (WbFieldChecker::resetDoubleIfNegative(this, mExposure, 1.0))
     return;
 
 #ifdef _WIN32

--- a/src/webots/nodes/WbWorldInfo.cpp
+++ b/src/webots/nodes/WbWorldInfo.cpp
@@ -181,11 +181,11 @@ void WbWorldInfo::createOdeObjects() {
 }
 
 void WbWorldInfo::updateBasicTimeStep() {
-  WbFieldChecker::checkDoubleIsPositive(this, mBasicTimeStep, 32.0);
+  WbFieldChecker::resetDoubleIfNonPositive(this, mBasicTimeStep, 32.0);
 }
 
 void WbWorldInfo::updateFps() {
-  WbFieldChecker::checkDoubleIsPositive(this, mFps, 60.0);
+  WbFieldChecker::resetDoubleIfNonPositive(this, mFps, 60.0);
 }
 
 void WbWorldInfo::displayOptimalThreadCountWarning() {
@@ -204,12 +204,12 @@ void WbWorldInfo::updateOptimalThreadCount() {
   int threadPreferenceNumber = WbPreferences::instance()->value("General/numberOfThreads", 1).toInt();
   if (mOptimalThreadCount->value() > threadPreferenceNumber)
     warn(tr("A limit of '%1' threads is set in the preferences.").arg(threadPreferenceNumber));
-  else if (!WbFieldChecker::checkIntIsPositive(this, mOptimalThreadCount, 1))
+  else if (!WbFieldChecker::resetIntIfNonPositive(this, mOptimalThreadCount, 1))
     emit optimalThreadCountChanged();
 }
 
 void WbWorldInfo::updateLineScale() {
-  if (WbFieldChecker::checkDoubleIsNonNegative(this, mLineScale, 0.0))
+  if (WbFieldChecker::resetDoubleIfNegative(this, mLineScale, 0.0))
     return;
 
   if (areWrenObjectsInitialized())
@@ -221,7 +221,7 @@ void WbWorldInfo::applyLineScaleToWren() {
 }
 
 void WbWorldInfo::updateRandomSeed() {
-  WbFieldChecker::checkIntIsNonNegativeOrDisabled(this, mRandomSeed, 0, -1);
+  WbFieldChecker::resetIntIfNegativeAndNotDisabled(this, mRandomSeed, 0, -1);
   emit randomSeedChanged();
 }
 
@@ -242,7 +242,7 @@ void WbWorldInfo::applyToOdeGravity() {
 }
 
 void WbWorldInfo::updateCfm() {
-  if (WbFieldChecker::checkDoubleIsPositive(this, mCfm, 0.00001))
+  if (WbFieldChecker::resetDoubleIfNonPositive(this, mCfm, 0.00001))
     return;
 
   if (areOdeObjectsCreated())
@@ -255,7 +255,7 @@ void WbWorldInfo::applyToOdeCfm() {
 }
 
 void WbWorldInfo::updateErp() {
-  if (WbFieldChecker::checkDoubleInRangeWithIncludedBounds(this, mErp, 0.0, 1.0, 0.2))
+  if (WbFieldChecker::resetDoubleIfNotInRangeWithIncludedBounds(this, mErp, 0.0, 1.0, 0.2))
     return;
 
   if (areOdeObjectsCreated())

--- a/src/webots/nodes/WbZoom.cpp
+++ b/src/webots/nodes/WbZoom.cpp
@@ -51,7 +51,7 @@ void WbZoom::postFinalize() {
 }
 
 void WbZoom::updateMinFieldOfView() {
-  if (WbFieldChecker::checkDoubleIsNonNegative(this, mMinFieldOfView, 0.0))
+  if (WbFieldChecker::resetDoubleIfNegative(this, mMinFieldOfView, 0.0))
     return;
   if (mMinFieldOfView->value() > mMaxFieldOfView->value()) {
     warn(tr("Invalid 'minFieldOfView' changed to %1. The value should be smaller or equal to 'maxFieldOfView'.")

--- a/src/webots/nodes/utils/WbFieldChecker.cpp
+++ b/src/webots/nodes/utils/WbFieldChecker.cpp
@@ -39,7 +39,7 @@ Hence:
 - "x is non-positive" means "x <= 0"
 */
 
-bool WbFieldChecker::checkDoubleIsNonNegative(const WbBaseNode *node, WbSFDouble *value, double defaultValue) {
+bool WbFieldChecker::resetDoubleIfNegative(const WbBaseNode *node, WbSFDouble *value, double defaultValue) {
   if (value->value() < 0) {
     const WbField *field = findField(node, value);
     node->warn(tr("Invalid '%1' changed to %2. The value should be non-negative.").arg(field->name()).arg(defaultValue));
@@ -49,17 +49,7 @@ bool WbFieldChecker::checkDoubleIsNonNegative(const WbBaseNode *node, WbSFDouble
   return false;
 }
 
-bool WbFieldChecker::checkDoubleIsNonPositive(const WbBaseNode *node, WbSFDouble *value, double defaultValue) {
-  if (value->value() > 0) {
-    const WbField *field = findField(node, value);
-    node->warn(tr("Invalid '%1' changed to %2. The value should be non-positive.").arg(field->name()).arg(defaultValue));
-    value->setValue(defaultValue);
-    return true;
-  }
-  return false;
-}
-
-bool WbFieldChecker::checkDoubleIsPositive(const WbBaseNode *node, WbSFDouble *value, double defaultValue) {
+bool WbFieldChecker::resetDoubleIfNonPositive(const WbBaseNode *node, WbSFDouble *value, double defaultValue) {
   if (value->value() <= 0) {
     const WbField *field = findField(node, value);
     node->warn(tr("Invalid '%1' changed to %2. The value should be positive.").arg(field->name()).arg(defaultValue));
@@ -69,8 +59,8 @@ bool WbFieldChecker::checkDoubleIsPositive(const WbBaseNode *node, WbSFDouble *v
   return false;
 }
 
-bool WbFieldChecker::checkDoubleIsNonNegativeOrDisabled(const WbBaseNode *node, WbSFDouble *value, double defaultValue,
-                                                        double disableValue) {
+bool WbFieldChecker::resetDoubleIfNegativeAndNotDisabled(const WbBaseNode *node, WbSFDouble *value, double defaultValue,
+                                                         double disableValue) {
   if (value->value() < 0 && (value->value() != disableValue)) {
     const WbField *field = findField(node, value);
     node->warn(tr("Invalid '%1' changed to %2. The value should be either %3 or non-negative.")
@@ -83,8 +73,8 @@ bool WbFieldChecker::checkDoubleIsNonNegativeOrDisabled(const WbBaseNode *node, 
   return false;
 }
 
-bool WbFieldChecker::checkDoubleIsPositiveOrDisabled(const WbBaseNode *node, WbSFDouble *value, double defaultValue,
-                                                     double disableValue) {
+bool WbFieldChecker::resetDoubleIfNonPositiveAndNotDisabled(const WbBaseNode *node, WbSFDouble *value, double defaultValue,
+                                                            double disableValue) {
   if (value->value() <= 0 && (value->value() != disableValue)) {
     const WbField *field = findField(node, value);
     node->warn(tr("Invalid '%1' changed to %2. The value should be either %3 or positive.")
@@ -97,8 +87,9 @@ bool WbFieldChecker::checkDoubleIsPositiveOrDisabled(const WbBaseNode *node, WbS
   return false;
 }
 
-bool WbFieldChecker::checkDoubleIsInRangeWithIncludedBoundsOrDisabled(const WbBaseNode *node, WbSFDouble *value, double min,
-                                                                      double max, double disableValue, double defaultValue) {
+bool WbFieldChecker::resetDoubleIfNotInRangeWithIncludedBoundsAndNotDisabled(const WbBaseNode *node, WbSFDouble *value,
+                                                                             double min, double max, double disableValue,
+                                                                             double defaultValue) {
   if (value->value() != disableValue && (value->value() < min || value->value() > max)) {
     const WbField *field = findField(node, value);
     node->warn(tr("Invalid '%1' changed to %2. The value should be in either %3 or in range [%4, %5].")
@@ -113,8 +104,8 @@ bool WbFieldChecker::checkDoubleIsInRangeWithIncludedBoundsOrDisabled(const WbBa
   return false;
 }
 
-bool WbFieldChecker::checkDoubleInRangeWithIncludedBounds(const WbBaseNode *node, WbSFDouble *value, double min, double max,
-                                                          double defaultValue) {
+bool WbFieldChecker::resetDoubleIfNotInRangeWithIncludedBounds(const WbBaseNode *node, WbSFDouble *value, double min,
+                                                               double max, double defaultValue) {
   if (value->value() < min || value->value() > max) {
     const WbField *field = findField(node, value);
     node->warn(tr("Invalid '%1' changed to %2. The value should be in range [%3, %4].")
@@ -128,8 +119,7 @@ bool WbFieldChecker::checkDoubleInRangeWithIncludedBounds(const WbBaseNode *node
   return false;
 }
 
-bool WbFieldChecker::checkAndClampDoubleInRangeWithIncludedBounds(const WbBaseNode *node, WbSFDouble *value, double min,
-                                                                  double max) {
+bool WbFieldChecker::clampDoubleToRangeWithIncludedBounds(const WbBaseNode *node, WbSFDouble *value, double min, double max) {
   double defaultValue = value->value();
   if (value->value() < min)
     defaultValue = min;
@@ -149,8 +139,8 @@ bool WbFieldChecker::checkAndClampDoubleInRangeWithIncludedBounds(const WbBaseNo
   return false;
 }
 
-bool WbFieldChecker::checkDoubleInRangeWithExcludedBounds(const WbBaseNode *node, WbSFDouble *value, double min, double max,
-                                                          double defaultValue) {
+bool WbFieldChecker::resetDoubleIfNotInRangeWithExcludedBounds(const WbBaseNode *node, WbSFDouble *value, double min,
+                                                               double max, double defaultValue) {
   if (value->value() <= min || value->value() >= max) {
     const WbField *field = findField(node, value);
     node->warn(tr("Invalid '%1' changed to %2. The value should be in range ]%3, %4[.")
@@ -164,8 +154,7 @@ bool WbFieldChecker::checkDoubleInRangeWithExcludedBounds(const WbBaseNode *node
   return false;
 }
 
-bool WbFieldChecker::checkDoubleIsGreaterOrEqual(const WbBaseNode *node, WbSFDouble *value, double threshold,
-                                                 double defaultValue) {
+bool WbFieldChecker::resetDoubleIfLess(const WbBaseNode *node, WbSFDouble *value, double threshold, double defaultValue) {
   if (value->value() < threshold) {
     const WbField *field = findField(node, value);
     node->warn(
@@ -176,21 +165,7 @@ bool WbFieldChecker::checkDoubleIsGreaterOrEqual(const WbBaseNode *node, WbSFDou
   return false;
 }
 
-bool WbFieldChecker::checkDoubleIsGreater(const WbBaseNode *node, WbSFDouble *value, double threshold, double defaultValue) {
-  if (value->value() <= threshold) {
-    const WbField *field = findField(node, value);
-    node->warn(tr("Invalid '%1' changed to %2. The value should be greater than %3.")
-                 .arg(field->name())
-                 .arg(defaultValue)
-                 .arg(threshold));
-    value->setValue(defaultValue);
-    return true;
-  }
-  return false;
-}
-
-bool WbFieldChecker::checkDoubleIsLessOrEqual(const WbBaseNode *node, WbSFDouble *value, double threshold,
-                                              double defaultValue) {
+bool WbFieldChecker::resetDoubleIfGreater(const WbBaseNode *node, WbSFDouble *value, double threshold, double defaultValue) {
   if (value->value() > threshold) {
     const WbField *field = findField(node, value);
     node->warn(
@@ -201,18 +176,7 @@ bool WbFieldChecker::checkDoubleIsLessOrEqual(const WbBaseNode *node, WbSFDouble
   return false;
 }
 
-bool WbFieldChecker::checkDoubleIsLess(const WbBaseNode *node, WbSFDouble *value, double threshold, double defaultValue) {
-  if (value->value() >= threshold) {
-    const WbField *field = findField(node, value);
-    node->warn(
-      tr("Invalid '%1' changed to %2. The value should be less than %3.").arg(field->name()).arg(defaultValue).arg(threshold));
-    value->setValue(defaultValue);
-    return true;
-  }
-  return false;
-}
-
-bool WbFieldChecker::checkIntIsNonNegative(const WbBaseNode *node, WbSFInt *value, int defaultValue) {
+bool WbFieldChecker::resetIntIfNegative(const WbBaseNode *node, WbSFInt *value, int defaultValue) {
   if (value->value() < 0) {
     const WbField *field = findField(node, value);
     node->warn(tr("Invalid '%1' changed to %2. The value should be non-negative.").arg(field->name()).arg(defaultValue));
@@ -222,7 +186,7 @@ bool WbFieldChecker::checkIntIsNonNegative(const WbBaseNode *node, WbSFInt *valu
   return false;
 }
 
-bool WbFieldChecker::checkIntIsPositive(const WbBaseNode *node, WbSFInt *value, int defaultValue) {
+bool WbFieldChecker::resetIntIfNonPositive(const WbBaseNode *node, WbSFInt *value, int defaultValue) {
   if (value->value() <= 0) {
     const WbField *field = findField(node, value);
     node->warn(tr("Invalid '%1' changed to %2. The value should be positive.").arg(field->name()).arg(defaultValue));
@@ -232,7 +196,7 @@ bool WbFieldChecker::checkIntIsPositive(const WbBaseNode *node, WbSFInt *value, 
   return false;
 }
 
-bool WbFieldChecker::checkIntIsGreaterOrEqual(const WbBaseNode *node, WbSFInt *value, int threshold, int defaultValue) {
+bool WbFieldChecker::resetIntIfLess(const WbBaseNode *node, WbSFInt *value, int threshold, int defaultValue) {
   if (value->value() < threshold) {
     const WbField *field = findField(node, value);
     node->warn(
@@ -243,8 +207,8 @@ bool WbFieldChecker::checkIntIsGreaterOrEqual(const WbBaseNode *node, WbSFInt *v
   return false;
 }
 
-bool WbFieldChecker::checkIntInRangeWithIncludedBounds(const WbBaseNode *node, WbSFInt *value, int min, int max,
-                                                       int defaultValue) {
+bool WbFieldChecker::resetIntIfNotInRangeWithIncludedBounds(const WbBaseNode *node, WbSFInt *value, int min, int max,
+                                                            int defaultValue) {
   if (value->value() < min || value->value() > max) {
     const WbField *field = findField(node, value);
     node->warn(tr("Invalid '%1' changed to %2. The value should be in range [%3, %4].")
@@ -258,7 +222,8 @@ bool WbFieldChecker::checkIntInRangeWithIncludedBounds(const WbBaseNode *node, W
   return false;
 }
 
-bool WbFieldChecker::checkIntIsPositiveOrDisabled(const WbBaseNode *node, WbSFInt *value, int defaultValue, int disableValue) {
+bool WbFieldChecker::resetIntIfNonPositiveAndNotDisabled(const WbBaseNode *node, WbSFInt *value, int defaultValue,
+                                                         int disableValue) {
   if (value->value() <= 0 && value->value() != disableValue) {
     const WbField *field = findField(node, value);
     node->warn(tr("Invalid '%1' changed to %2. The value should be either %3 or positive.")
@@ -271,8 +236,8 @@ bool WbFieldChecker::checkIntIsPositiveOrDisabled(const WbBaseNode *node, WbSFIn
   return false;
 }
 
-bool WbFieldChecker::checkIntIsNonNegativeOrDisabled(const WbBaseNode *node, WbSFInt *value, int defaultValue,
-                                                     int disableValue) {
+bool WbFieldChecker::resetIntIfNegativeAndNotDisabled(const WbBaseNode *node, WbSFInt *value, int defaultValue,
+                                                      int disableValue) {
   if (value->value() < 0 && value->value() != disableValue) {
     const WbField *field = findField(node, value);
     node->warn(tr("Invalid '%1' changed to %2. The value should be either %3 or non-negative.")
@@ -285,7 +250,7 @@ bool WbFieldChecker::checkIntIsNonNegativeOrDisabled(const WbBaseNode *node, WbS
   return false;
 }
 
-bool WbFieldChecker::checkVector2IsPositive(const WbBaseNode *node, WbSFVector2 *value, const WbVector2 &defaultValue) {
+bool WbFieldChecker::resetVector2IfNonPositive(const WbBaseNode *node, WbSFVector2 *value, const WbVector2 &defaultValue) {
   if (value->x() <= 0 || value->y() <= 0) {
     const WbField *field = findField(node, value);
     node->warn(tr("Invalid '%1' changed to %2. The value should be positive.")
@@ -297,7 +262,7 @@ bool WbFieldChecker::checkVector2IsPositive(const WbBaseNode *node, WbSFVector2 
   return false;
 }
 
-bool WbFieldChecker::checkVector3IsNonNegative(const WbBaseNode *node, WbSFVector3 *value, const WbVector3 &defaultValue) {
+bool WbFieldChecker::resetVector3IfNegative(const WbBaseNode *node, WbSFVector3 *value, const WbVector3 &defaultValue) {
   if (value->x() < 0 || value->y() < 0 || value->z() < 0) {
     const WbField *field = findField(node, value);
     node->warn(tr("Invalid '%1' changed to %2. The value should be non-negative.")
@@ -309,7 +274,7 @@ bool WbFieldChecker::checkVector3IsNonNegative(const WbBaseNode *node, WbSFVecto
   return false;
 }
 
-bool WbFieldChecker::checkVector3IsPositive(const WbBaseNode *node, WbSFVector3 *value, const WbVector3 &defaultValue) {
+bool WbFieldChecker::resetVector3IfNonPositive(const WbBaseNode *node, WbSFVector3 *value, const WbVector3 &defaultValue) {
   if (value->x() <= 0 || value->y() <= 0 || value->z() <= 0) {
     const WbField *field = findField(node, value);
     node->warn(tr("Invalid '%1' changed to %2. The value should be positive.")
@@ -321,9 +286,9 @@ bool WbFieldChecker::checkVector3IsPositive(const WbBaseNode *node, WbSFVector3 
   return false;
 }
 
-bool WbFieldChecker::checkColorIsValid(const WbBaseNode *node, WbSFColor *value) {
+bool WbFieldChecker::resetColorIfInvalid(const WbBaseNode *node, WbSFColor *value) {
   WbRgb rgb = value->value();
-  if (checkRgbIsValid(rgb)) {
+  if (clampRgb(rgb)) {
     const WbField *field = findField(node, value);
     node->warn(tr("Invalid '%1' changed to %2.").arg(field->name()).arg(rgb.toString(WbPrecision::GUI_MEDIUM)));
     value->setValue(rgb);
@@ -332,13 +297,13 @@ bool WbFieldChecker::checkColorIsValid(const WbBaseNode *node, WbSFColor *value)
   return false;
 }
 
-bool WbFieldChecker::checkMultipleColorIsValid(const WbBaseNode *node, WbMFColor *value) {
+bool WbFieldChecker::resetMultipleColorIfInvalid(const WbBaseNode *node, WbMFColor *value) {
   bool changed = false;
   int size = value->size();
   const WbField *field = findField(node, value);
   for (int i = 0; i < size; i++) {
     WbRgb rgb = value->item(i);
-    if (checkRgbIsValid(rgb)) {
+    if (clampRgb(rgb)) {
       node->warn(
         tr("Invalid item %1 of '%2' changed to %3.").arg(i).arg(field->name()).arg(rgb.toString(WbPrecision::GUI_MEDIUM)));
       value->setItem(i, rgb);
@@ -355,7 +320,7 @@ const WbField *WbFieldChecker::findField(const WbBaseNode *node, WbValue *value)
   return NULL;
 }
 
-bool WbFieldChecker::checkRgbIsValid(WbRgb &rgb) {
+bool WbFieldChecker::clampRgb(WbRgb &rgb) {
   bool changed = false;
 
   if (rgb.red() < 0.0) {

--- a/src/webots/nodes/utils/WbFieldChecker.hpp
+++ b/src/webots/nodes/utils/WbFieldChecker.hpp
@@ -41,45 +41,43 @@ class WbFieldChecker : public QObject {
   Q_OBJECT
 
 public:
-  static bool checkDoubleIsNonNegative(const WbBaseNode *node, WbSFDouble *value, double defaultValue);
-  static bool checkDoubleIsNonPositive(const WbBaseNode *node, WbSFDouble *value, double defaultValue);
-  static bool checkDoubleIsPositive(const WbBaseNode *node, WbSFDouble *value, double defaultValue);
-  static bool checkDoubleInRangeWithIncludedBounds(const WbBaseNode *node, WbSFDouble *value, double min, double max,
-                                                   double defaultValue);
-  static bool checkDoubleInRangeWithExcludedBounds(const WbBaseNode *node, WbSFDouble *value, double min, double max,
-                                                   double defaultValue);
-  static bool checkDoubleIsGreaterOrEqual(const WbBaseNode *node, WbSFDouble *value, double threshold, double defaultValue);
-  static bool checkDoubleIsGreater(const WbBaseNode *node, WbSFDouble *value, double threshold, double defaultValue);
-  static bool checkDoubleIsLessOrEqual(const WbBaseNode *node, WbSFDouble *value, double threshold, double defaultValue);
-  static bool checkDoubleIsLess(const WbBaseNode *node, WbSFDouble *value, double threshold, double defaultValue);
-  static bool checkDoubleIsNonNegativeOrDisabled(const WbBaseNode *node, WbSFDouble *value, double defaultValue,
-                                                 double disableValue);
-  static bool checkDoubleIsPositiveOrDisabled(const WbBaseNode *node, WbSFDouble *value, double defaultValue,
-                                              double disableValue);
-  static bool checkDoubleIsInRangeWithIncludedBoundsOrDisabled(const WbBaseNode *node, WbSFDouble *value, double min,
-                                                               double max, double disableValue, double defaultValue);
+  static bool resetDoubleIfNegative(const WbBaseNode *node, WbSFDouble *value, double defaultValue);
+  static bool resetDoubleIfNonPositive(const WbBaseNode *node, WbSFDouble *value, double defaultValue);
+  static bool resetDoubleIfNotInRangeWithIncludedBounds(const WbBaseNode *node, WbSFDouble *value, double min, double max,
+                                                        double defaultValue);
+  static bool resetDoubleIfNotInRangeWithExcludedBounds(const WbBaseNode *node, WbSFDouble *value, double min, double max,
+                                                        double defaultValue);
+  static bool resetDoubleIfLess(const WbBaseNode *node, WbSFDouble *value, double threshold, double defaultValue);
+  static bool resetDoubleIfGreater(const WbBaseNode *node, WbSFDouble *value, double threshold, double defaultValue);
+  static bool resetDoubleIfNegativeAndNotDisabled(const WbBaseNode *node, WbSFDouble *value, double defaultValue,
+                                                  double disableValue);
+  static bool resetDoubleIfNonPositiveAndNotDisabled(const WbBaseNode *node, WbSFDouble *value, double defaultValue,
+                                                     double disableValue);
+  static bool resetDoubleIfNotInRangeWithIncludedBoundsAndNotDisabled(const WbBaseNode *node, WbSFDouble *value, double min,
+                                                                      double max, double disableValue, double defaultValue);
 
-  static bool checkAndClampDoubleInRangeWithIncludedBounds(const WbBaseNode *node, WbSFDouble *value, double min, double max);
+  static bool clampDoubleToRangeWithIncludedBounds(const WbBaseNode *node, WbSFDouble *value, double min, double max);
 
-  static bool checkIntIsNonNegative(const WbBaseNode *node, WbSFInt *value, int defaultValue);
-  static bool checkIntIsPositive(const WbBaseNode *node, WbSFInt *value, int defaultValue);
-  static bool checkIntIsGreaterOrEqual(const WbBaseNode *node, WbSFInt *value, int threshold, int defaultValue);
-  static bool checkIntInRangeWithIncludedBounds(const WbBaseNode *node, WbSFInt *value, int min, int max, int defaultValue);
-  static bool checkIntIsPositiveOrDisabled(const WbBaseNode *node, WbSFInt *value, int defaultValue, int disableValue);
-  static bool checkIntIsNonNegativeOrDisabled(const WbBaseNode *node, WbSFInt *value, int defaultValue, int disableValue);
+  static bool resetIntIfNegative(const WbBaseNode *node, WbSFInt *value, int defaultValue);
+  static bool resetIntIfNonPositive(const WbBaseNode *node, WbSFInt *value, int defaultValue);
+  static bool resetIntIfLess(const WbBaseNode *node, WbSFInt *value, int threshold, int defaultValue);
+  static bool resetIntIfNotInRangeWithIncludedBounds(const WbBaseNode *node, WbSFInt *value, int min, int max,
+                                                     int defaultValue);
+  static bool resetIntIfNonPositiveAndNotDisabled(const WbBaseNode *node, WbSFInt *value, int defaultValue, int disableValue);
+  static bool resetIntIfNegativeAndNotDisabled(const WbBaseNode *node, WbSFInt *value, int defaultValue, int disableValue);
 
-  static bool checkVector2IsPositive(const WbBaseNode *node, WbSFVector2 *value, const WbVector2 &defaultValue);
+  static bool resetVector2IfNonPositive(const WbBaseNode *node, WbSFVector2 *value, const WbVector2 &defaultValue);
 
-  static bool checkVector3IsNonNegative(const WbBaseNode *node, WbSFVector3 *value, const WbVector3 &defaultValue);
-  static bool checkVector3IsPositive(const WbBaseNode *node, WbSFVector3 *value, const WbVector3 &defaultValue);
+  static bool resetVector3IfNegative(const WbBaseNode *node, WbSFVector3 *value, const WbVector3 &defaultValue);
+  static bool resetVector3IfNonPositive(const WbBaseNode *node, WbSFVector3 *value, const WbVector3 &defaultValue);
 
-  static bool checkColorIsValid(const WbBaseNode *node, WbSFColor *value);
-  static bool checkMultipleColorIsValid(const WbBaseNode *node, WbMFColor *value);
+  static bool resetColorIfInvalid(const WbBaseNode *node, WbSFColor *value);
+  static bool resetMultipleColorIfInvalid(const WbBaseNode *node, WbMFColor *value);
 
 private:
   static const WbField *findField(const WbBaseNode *node, WbValue *value);
 
-  static bool checkRgbIsValid(WbRgb &rgb);
+  static bool clampRgb(WbRgb &rgb);
 
   WbFieldChecker() {}
 };


### PR DESCRIPTION
Addresses #438:
the `WbFieldChecker` functions have been renamed so that instead of `check<type>Is<condition>` are now called `reset<type>If<condition>` to better describe the function behavior that not only checks the field value but also reset it to a default value if the condition is not satisfied.