### PR TITLE
Macos Travis Test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ language: python
 python:
   - "2.7"
   - "3.7"
+matrix:  # macos can't be listed in 'os' as we need to set 'generic' as language (because travis doesn't support python on macos for now)
+  include:
+    - os: osx
+      language: generic
 cache: pip
 install:
   - pip install -r tests/sources/requirements.txt
@@ -14,6 +18,10 @@ addons:
   apt:
     packages:
       - clang-format-5.0
+  homebrew:
+    packages:
+      - clang-format
+      - python
 script:
   - python -m unittest discover -s tests/sources
   - python -m unittest discover -s docs/tests

--- a/tests/sources/test_clang_format.py
+++ b/tests/sources/test_clang_format.py
@@ -91,7 +91,7 @@ class TestClangFormat(unittest.TestCase):
     def _runClangFormat(self, f):
         """Run clang format on 'f' file."""
         clangFormatCommand = "clang-format"
-        if 'TRAVIS' in os.environ:
+        if 'TRAVIS' in os.environ and 'TRAVIS_OS_NAME' in os.environ and os.environ['TRAVIS_OS_NAME'] == 'linux':
             clangFormatCommand = "clang-format-5.0"
         return subprocess.check_output([clangFormatCommand, "-style=file", f])
 


### PR DESCRIPTION
Travis doesn't support officially tests written in Python, but I have been able to make it works by using the 'generic' language and manually installing python with brew.