### PR TITLE
Fix Various Python Regex.

### DIFF
--- a/docs/tests/test_references.py
+++ b/docs/tests/test_references.py
@@ -10,7 +10,7 @@ import re
 def slugify(txt):
     """Slugify function."""
     output = txt.lower()
-    output = re.sub('\([^)]*\)', '', output)  # remove the content of parenthesis
+    output = re.sub(r'\([^)]*\)', '', output)  # remove the content of parenthesis
     output = re.sub(r'<[^>]+>', '', output)
     output = output.replace('+', 'p')
     output = re.sub(r"[\(\):`']", '', output)

--- a/docs/tests/test_titles.py
+++ b/docs/tests/test_titles.py
@@ -76,9 +76,9 @@ class TestTitles(unittest.TestCase):
         """Test that title words are capitalized."""
         # English rules reference: http://grammar.yourdictionary.com/capitalization/rules-for-capitalization-in-titles.html
         # Chosen style: "Chicago Manual of Style"
-        uppercasePattern = re.compile('^[A-Z]')
-        lowercasePattern = re.compile('^[a-z][^A-Z]*$')
-        numberPattern = re.compile('^\d')
+        uppercasePattern = re.compile(r'^[A-Z]')
+        lowercasePattern = re.compile(r'^[a-z][^A-Z]*$')
+        numberPattern = re.compile(r'^\d')
         for t in self.titles:
             title = re.sub(r'^#+\s*', '', t['title'])  # Remove the '#'+ suffix.
             title = re.sub(r'".+?(?=")"', '', title)  # Remove double-quoted statements.

--- a/resources/osm_importer/importer.py
+++ b/resources/osm_importer/importer.py
@@ -94,10 +94,10 @@ maxlon = float('nan')
 lines = open(options.inFile).read().splitlines()
 for line in lines:
     if 'bounds' in line:
-        minlat = float(re.findall('[-+]?\d*\.\d+|\d+', line[line.find('minlat'):])[0])
-        minlon = float(re.findall('[-+]?\d*\.\d+|\d+', line[line.find('minlon'):])[0])
-        maxlat = float(re.findall('[-+]?\d*\.\d+|\d+', line[line.find('maxlat'):])[0])
-        maxlon = float(re.findall('[-+]?\d*\.\d+|\d+', line[line.find('maxlon'):])[0])
+        minlat = float(re.findall(r'[-+]?\d*\.\d+|\d+', line[line.find('minlat'):])[0])
+        minlon = float(re.findall(r'[-+]?\d*\.\d+|\d+', line[line.find('minlon'):])[0])
+        maxlat = float(re.findall(r'[-+]?\d*\.\d+|\d+', line[line.find('maxlat'):])[0])
+        maxlon = float(re.findall(r'[-+]?\d*\.\d+|\d+', line[line.find('maxlon'):])[0])
 if math.isnan(minlat) or math.isnan(minlon) or math.isnan(maxlat) or math.isnan(maxlon):
     sys.stderr.write('Warning: impossible to get the map bounds from the OSM file,'
                      ' make sure the file contains the "bounds" tag.\n')

--- a/resources/sumo_exporter/re_definitions.py
+++ b/resources/sumo_exporter/re_definitions.py
@@ -1,5 +1,5 @@
 """Regex definitions."""
 
 # https://stackoverflow.com/a/4703508
-floatRE = '[-+]?(?:(?:\d*\.\d+)|(?:\d+\.?))(?:[Ee][+-]?\d+)?'
-intRE = '[-+]?\d+(?:[Ee][+-]?\d+)?'
+floatRE = r'[-+]?(?:(?:\d*\.\d+)|(?:\d+\.?))(?:[Ee][+-]?\d+)?'
+intRE = r'[-+]?\d+(?:[Ee][+-]?\d+)?'


### PR DESCRIPTION
Python 3 interprets string literals as Unicode strings, and therefore the `\d` is treated as an escaped Unicode character causing the following pep8 warning: `DeprecationWarning: invalid escape sequence \d`