### PR TITLE
fixed world's bounds check

### DIFF
--- a/resources/osm_importer/importer.py
+++ b/resources/osm_importer/importer.py
@@ -15,7 +15,6 @@
 """Importer for writing a Webots worlds from an Open Street Map file."""
 
 import codecs
-import math
 import optparse
 import os
 import re

--- a/resources/osm_importer/importer.py
+++ b/resources/osm_importer/importer.py
@@ -103,7 +103,7 @@ for line in lines:
         temp = float(re.findall(r'[-+]?\d*\.\d+|\d+', line[line.find('maxlat'):])[0])
         if maxlat is None or maxlat < temp:
             maxlat = temp
-        temp = float(re.findall('[-+]?\d*\.\d+|\d+', line[line.find('maxlon'):])[0])
+        temp = float(re.findall(r'[-+]?\d*\.\d+|\d+', line[line.find('maxlon'):])[0])
         if maxlon is None or maxlon < temp:
             maxlon = temp
 

--- a/resources/osm_importer/importer.py
+++ b/resources/osm_importer/importer.py
@@ -97,7 +97,7 @@ for line in lines:
         temp = float(re.findall(r'[-+]?\d*\.\d+|\d+', line[line.find('minlat'):])[0])
         if minlat is None or minlat > temp:
             minlat = temp
-        temp = float(re.findall('[-+]?\d*\.\d+|\d+', line[line.find('minlon'):])[0])
+        temp = float(re.findall(r'[-+]?\d*\.\d+|\d+', line[line.find('minlon'):])[0])
         if minlon is None or minlon > temp:
             minlon = temp
         temp = float(re.findall('[-+]?\d*\.\d+|\d+', line[line.find('maxlat'):])[0])

--- a/resources/osm_importer/importer.py
+++ b/resources/osm_importer/importer.py
@@ -100,7 +100,7 @@ for line in lines:
         temp = float(re.findall(r'[-+]?\d*\.\d+|\d+', line[line.find('minlon'):])[0])
         if minlon is None or minlon > temp:
             minlon = temp
-        temp = float(re.findall('[-+]?\d*\.\d+|\d+', line[line.find('maxlat'):])[0])
+        temp = float(re.findall(r'[-+]?\d*\.\d+|\d+', line[line.find('maxlat'):])[0])
         if maxlat is None or maxlat < temp:
             maxlat = temp
         temp = float(re.findall('[-+]?\d*\.\d+|\d+', line[line.find('maxlon'):])[0])

--- a/resources/osm_importer/importer.py
+++ b/resources/osm_importer/importer.py
@@ -87,18 +87,27 @@ if not os.path.isfile(options.inFile):
 random.seed(0)
 
 # check for the bounds of the world
-minlat = float('nan')
-minlon = float('nan')
-maxlat = float('nan')
-maxlon = float('nan')
+minlat = None
+minlon = None
+maxlat = None
+maxlon = None
 lines = open(options.inFile).read().splitlines()
 for line in lines:
     if 'bounds' in line:
-        minlat = float(re.findall(r'[-+]?\d*\.\d+|\d+', line[line.find('minlat'):])[0])
-        minlon = float(re.findall(r'[-+]?\d*\.\d+|\d+', line[line.find('minlon'):])[0])
-        maxlat = float(re.findall(r'[-+]?\d*\.\d+|\d+', line[line.find('maxlat'):])[0])
-        maxlon = float(re.findall(r'[-+]?\d*\.\d+|\d+', line[line.find('maxlon'):])[0])
-if math.isnan(minlat) or math.isnan(minlon) or math.isnan(maxlat) or math.isnan(maxlon):
+        temp = float(re.findall('[-+]?\d*\.\d+|\d+', line[line.find('minlat'):])[0])
+        if minlat is None or minlat > temp:
+            minlat = temp
+        temp = float(re.findall('[-+]?\d*\.\d+|\d+', line[line.find('minlon'):])[0])
+        if minlon is None or minlon > temp:
+            minlon = temp
+        temp = float(re.findall('[-+]?\d*\.\d+|\d+', line[line.find('maxlat'):])[0])
+        if maxlat is None or maxlat < temp:
+            maxlat = temp
+        temp = float(re.findall('[-+]?\d*\.\d+|\d+', line[line.find('maxlon'):])[0])
+        if maxlon is None or maxlon < temp:
+            maxlon = temp
+
+if minlat is None or minlon is None or maxlat is None or maxlon is None:
     sys.stderr.write('Warning: impossible to get the map bounds from the OSM file,'
                      ' make sure the file contains the "bounds" tag.\n')
     sys.exit(0)

--- a/resources/osm_importer/importer.py
+++ b/resources/osm_importer/importer.py
@@ -94,7 +94,7 @@ maxlon = None
 lines = open(options.inFile).read().splitlines()
 for line in lines:
     if 'bounds' in line:
-        temp = float(re.findall('[-+]?\d*\.\d+|\d+', line[line.find('minlat'):])[0])
+        temp = float(re.findall(r'[-+]?\d*\.\d+|\d+', line[line.find('minlat'):])[0])
         if minlat is None or minlat > temp:
             minlat = temp
         temp = float(re.findall('[-+]?\d*\.\d+|\d+', line[line.find('minlon'):])[0])


### PR DESCRIPTION
Hi,
I noticed that an osm file can have multiple <bounds> element like this example:

```xml
<osm version='0.6' generator='JOSM'>
  <bounds minlat='48.710233' minlon='2.1460891' maxlat='48.7189244' maxlon='2.1602205' origin='CGImap 0.6.1 (19297 thorn-02.openstreetmap.org)' />
  <bounds minlat='48.7189244' minlon='2.1512673' maxlat='48.7276158' maxlon='2.1602205' origin='CGImap 0.6.1 (26368 thorn-01.openstreetmap.org)' />
  <bounds minlat='48.7107509' minlon='2.1602205' maxlat='48.7120839' maxlon='2.1743519' origin='CGImap 0.6.1 (19277 thorn-02.openstreetmap.org)' />
  <bounds minlat='48.7272003' minlon='2.1602205' maxlat='48.730416' maxlon='2.1634099' origin='CGImap 0.6.1 (19296 thorn-02.openstreetmap.org)' />
  <bounds minlat='48.7117459' minlon='2.1743519' maxlat='48.7157548' maxlon='2.2026146' origin='CGImap 0.6.1 (19284 thorn-02.openstreetmap.org)' />
  <bounds minlat='48.7097397' minlon='2.2026146' maxlat='48.7143978' maxlon='2.216746' origin='CGImap 0.6.1 (26314 thorn-01.openstreetmap.org)' />
  <bounds minlat='48.7099737' minlon='2.216746' maxlat='48.7190563' maxlon='2.2308773' origin='CGImap 0.6.1 (19297 thorn-02.openstreetmap.org)' />
  <bounds minlat='48.7182262' minlon='2.2308773' maxlat='48.7244689' maxlon='2.2450087' origin='CGImap 0.6.1 (19269 thorn-02.openstreetmap.org)' />
  <bounds minlat='48.7198542' minlon='2.2450087' maxlat='48.7241499' maxlon='2.2591401' origin='CGImap 0.6.1 (19278 thorn-02.openstreetmap.org)' />
```

And the osm importer only considers one such element (the last one). I modified it to compute the bounding box of all the bounds.

Regards,