### PR TITLE
Improve hyperlink colors (hotfix)

### DIFF
--- a/docs/css/webots-doc.css
+++ b/docs/css/webots-doc.css
@@ -209,12 +209,12 @@ body {
 }
 .webots-doc a {
   font-family: "Roboto";
-  color: #317589;
+  color: #3e95af;
   text-decoration: none;
   outline: 0;
 }
 .webots-doc a:hover {
-  color: black;
+  color: #2a6576;
   text-decoration: none;
   outline: 0;
 }
@@ -222,7 +222,7 @@ body {
 .webots-doc a:focus {
   outline: 0;
   text-decoration: none;
-  color: black;
+  color: #2a6576;
 }
 .webots-doc pre {
   padding: 20px 10px 20px 40px;


### PR DESCRIPTION
Fix #502 

Process: start from the [original hyperlink color](https://www.colorhexa.com/317589), increase luminosity (along the monochromatic scale) for the unvisited hyperlinks, decrease the luminosity for the hyperlink events (active / hover). The difference is subtle but visible, good looking IMO.

Preview: https://cyberbotics.com/doc/guide/samples-environments?version=hotfix-hyperlink-colors