### PR TITLE
Fix UnicodeDecodeError when importing OSM on windows.

### DIFF
--- a/resources/osm_importer/importer.py
+++ b/resources/osm_importer/importer.py
@@ -90,7 +90,7 @@ minlat = None
 minlon = None
 maxlat = None
 maxlon = None
-lines = open(options.inFile).read().splitlines()
+lines = codecs.open(options.inFile, 'r', 'utf-8').read().splitlines()
 for line in lines:
     if 'bounds' in line:
         temp = float(re.findall(r'[-+]?\d*\.\d+|\d+', line[line.find('minlat'):])[0])


### PR DESCRIPTION
Use the codecs to correctly read in utf-8 file, preventing UnicodeDecodeError