### PR TITLE
Fix references to the dropped SphereGrid.cubeMap field

### DIFF
--- a/projects/samples/rendering/worlds/physically_based_rendering.wbt
+++ b/projects/samples/rendering/worlds/physically_based_rendering.wbt
@@ -25,7 +25,6 @@ DEF GOLD SphereGrid {
   normalMap NULL
   baseColorMap NULL
   roughnessMap NULL
-  cubeMap NULL
   transparency 0
   widthAndHeight 5
 }
@@ -36,7 +35,6 @@ DEF SILVER SphereGrid {
   normalMap NULL
   baseColorMap NULL
   roughnessMap NULL
-  cubeMap NULL
   transparency 0
   widthAndHeight 5
 }
@@ -47,7 +45,6 @@ DEF BLACK SphereGrid {
   normalMap NULL
   baseColorMap NULL
   roughnessMap NULL
-  cubeMap NULL
   transparency 0
   widthAndHeight 5
 }
@@ -58,7 +55,6 @@ DEF COPPER SphereGrid {
   normalMap NULL
   baseColorMap NULL
   roughnessMap NULL
-  cubeMap NULL
   transparency 0
   widthAndHeight 5
 }


### PR DESCRIPTION
`SphereGrid.cubeMap` has been dropped in #500 but few references remain.

This prevents `physically_based_rendering.wbt` to be loaded correctly.