### PR TITLE
Fix texture streaming

### DIFF
--- a/src/webots/vrml/WbVrmlWriter.cpp
+++ b/src/webots/vrml/WbVrmlWriter.cpp
@@ -32,7 +32,7 @@ WbVrmlWriter::WbVrmlWriter(QString *target, const QString &fileName) :
   QTextStream(target, QIODevice::ReadWrite),
   mFileName(fileName),
   mIndent(0),
-  mIsWritingToFile(true) {
+  mIsWritingToFile(false) {
   setVrmlType();
 }
 


### PR DESCRIPTION
In #495, a bool has been toggled causing issues in the streaming server: the textures are copied in WEBOTS_HOME.