### PR TITLE
Fix Python3 Libraries

### DIFF
--- a/projects/default/libraries/vehicle/Makefile
+++ b/projects/default/libraries/vehicle/Makefile
@@ -26,27 +26,29 @@ java: cpp/driver cpp/car
 	+@make -s -C $@ $(MAKECMDGOALS)
 
 python: cpp/driver cpp/car
-ifeq ($(OSTYPE), windows)
-	+@echo "# make" $(MAKECMDGOALS) python 3.7
-	+@make -s -C python $(MAKECMDGOALS)
-	+@echo "# make" $(MAKECMDGOALS) python 2.7
-	+@PATH="$(PYTHON27_HOME):$(PATH)" make -s -C python $(MAKECMDGOALS)
-endif
 ifeq ($(OSTYPE),linux)
-	+@echo "# make" $(MAKECMDGOALS) python 3.6
-	+@PYTHON_COMMAND=python3.6 make -s -C python $(MAKECMDGOALS)
-	@echo "# make" $(MAKECMDGOALS) python 2.7;
-	+@PYTHON_COMMAND=python2.7 make -s -C python $(MAKECMDGOALS)
+	@echo "# make" $@ python2.7;
+	+PYTHON_COMMAND=python2.7 make -s -C python $(MAKECMDGOALS)
 ifeq ($(UBUNTU_VERSION), 16.04)
-	@echo "# make" $(MAKECMDGOALS) python 3.5;
-	@+PYTHON_COMMAND=python3.5 make -s -C python $(MAKECMDGOALS)
+	@echo "# make" $@ python3.5;
+	+PYTHON_COMMAND=python3.5 make -s -C python $(MAKECMDGOALS)
 endif
+	@echo "# make" $@ python3.6;
+	+PYTHON_COMMAND=python3.6 make -s -C python $(MAKECMDGOALS)
+	@echo "# make" $@ python3.7;
+	+PYTHON_COMMAND=python3.7 make -s -C python $(MAKECMDGOALS)
+endif
+ifeq ($(OSTYPE),windows)
+	@echo "# make" $@ python3.7;
+	+make -s -C python $(MAKECMDGOALS)
+	@echo "# make" $@ python2.7;
+	+PATH="$(PYTHON27_HOME):$(PATH)" make -s -C python $(MAKECMDGOALS)
 endif
 ifeq ($(OSTYPE),darwin)
-	+@echo "# make" $(MAKECMDGOALS) python 3.7
-	+@PYTHON_COMMAND=python3.7 make -s -C python $(MAKECMDGOALS)
-	@echo "# make" $(MAKECMDGOALS) python 2.7;
-	+@PYTHON_COMMAND=python2.7 make -s -C python $(MAKECMDGOALS)
+	@echo "# make" $@ python2.7;
+	+make -s -C python $(MAKECMDGOALS)
+	@echo "# make" $@ python3.7;
+	+PYTHON_COMMAND=python3.7 make -s -C python $(MAKECMDGOALS)
 endif
 
 

--- a/projects/robots/robotis/darwin-op/libraries/Makefile
+++ b/projects/robots/robotis/darwin-op/libraries/Makefile
@@ -27,7 +27,12 @@ endif
 
 .PHONY: release debug profile clean
 
-release debug profile clean: $(TARGETS)
+release debug profile: $(TARGETS)
+	cp python27/_managers.so python  # kept for backword compatibility with < R2019b
+	cp python27/managers.py python
+
+clean: $(TARGETS)
+	rm -rf python/_managers.so python/managers.py
 
 managers.Makefile: robotis-op2.Makefile
 
@@ -36,5 +41,27 @@ managers.Makefile robotis-op2.Makefile:
 	+@make -s -C $(@:.Makefile=) $(MAKECMDGOALS)
 
 python.Makefile: managers.Makefile
-	+@echo "# make" $(MAKECMDGOALS) $(@:.Makefile=)
-	+@$(PYTHON_MAKE) -s -C $(@:.Makefile=) $(MAKECMDGOALS)
+ifeq ($(OSTYPE),linux)
+	@echo "# make" $@ python2.7;
+	+PYTHON_COMMAND=python2.7 make -s -C python $(MAKECMDGOALS)
+ifeq ($(UBUNTU_VERSION), 16.04)
+	@echo "# make" $@ python3.5;
+	+PYTHON_COMMAND=python3.5 make -s -C python $(MAKECMDGOALS)
+endif
+	@echo "# make" $@ python3.6;
+	+PYTHON_COMMAND=python3.6 make -s -C python $(MAKECMDGOALS)
+	@echo "# make" $@ python3.7;
+	+PYTHON_COMMAND=python3.7 make -s -C python $(MAKECMDGOALS)
+endif
+ifeq ($(OSTYPE),windows)
+	@echo "# make" $@ python3.7;
+	+make -s -C python $(MAKECMDGOALS)
+	@echo "# make" $@ python2.7;
+	+PATH="$(PYTHON27_HOME):$(PATH)" make -s -C python $(MAKECMDGOALS)
+endif
+ifeq ($(OSTYPE),darwin)
+	@echo "# make" $@ python2.7;
+	+make -s -C python $(MAKECMDGOALS)
+	@echo "# make" $@ python3.7;
+	+PYTHON_COMMAND=python3.7 make -s -C python $(MAKECMDGOALS)
+endif

--- a/projects/robots/robotis/darwin-op/libraries/python/Makefile
+++ b/projects/robots/robotis/darwin-op/libraries/python/Makefile
@@ -23,7 +23,6 @@ PYTHON_VERSION := $(shell $(PYTHON_COMMAND) --version 2>&1 | sed 's/.* \([0-9]\)
 PYTHON_SHORT_VERSION = $(subst .,,$(PYTHON_VERSION))
 PYTHON_FULL_VERSION := $(subst Python ,,$(shell $(PYTHON_COMMAND) --version 2>&1))
 PYTHON_LIB_FOLDER = ../python$(PYTHON_SHORT_VERSION)
-#WEBOTS_LIBRARY = 1
 MODULE_NAME = managers
 
 INTERFACE          = $(MODULE_NAME).i

--- a/projects/robots/robotis/darwin-op/libraries/python/Makefile
+++ b/projects/robots/robotis/darwin-op/libraries/python/Makefile
@@ -83,7 +83,7 @@ SWIG_EXISTS = $(shell which swig 2> /dev/null)
 
 ifeq (, $(shell which $(PYTHON_COMMAND) 2> /dev/null))
 release debug profile:
-	@echo -e "# \033[0;33mPython not installed, skipping Python API\033[0m"
+	@echo -e "# \033[0;33m(PYTHON_COMMAND) not installed, skipping Python API\033[0m"
 else ifeq ($(SWIG_EXISTS),)
 release debug profile:
 	@echo -e "# \033[0;33mSWIG not installed, skipping Python API\033[0m"
@@ -101,4 +101,4 @@ $(WRAPPER_OBJECT):$(WRAPPER)
 endif
 
 clean:
-	@rm -fr *.o *.cpp $(PYOUT) $(LIBRARY) $(MODULE_NAME).pyc
+	@rm -fr *.o *.cpp $(PYOUT) $(LIBRARY) $(MODULE_NAME).pyc __pycache__ $(PYTHON_LIB_FOLDER)/__pycache__

--- a/projects/robots/robotis/darwin-op/libraries/python/Makefile
+++ b/projects/robots/robotis/darwin-op/libraries/python/Makefile
@@ -83,7 +83,7 @@ SWIG_EXISTS = $(shell which swig 2> /dev/null)
 
 ifeq (, $(shell which $(PYTHON_COMMAND) 2> /dev/null))
 release debug profile:
-	@echo -e "# \033[0;33m(PYTHON_COMMAND) not installed, skipping Python API\033[0m"
+	@echo -e "# \033[0;33m$(PYTHON_COMMAND) not installed, skipping Python API\033[0m"
 else ifeq ($(SWIG_EXISTS),)
 release debug profile:
 	@echo -e "# \033[0;33mSWIG not installed, skipping Python API\033[0m"

--- a/projects/robots/robotis/darwin-op/libraries/python/Makefile
+++ b/projects/robots/robotis/darwin-op/libraries/python/Makefile
@@ -66,7 +66,7 @@ C_FLAGS          = -c -Wall -fPIC -mmacosx-version-min=$(MACOSX_MIN_SDK_VERSION)
 ifeq ($(findstring llvm-g++,$(shell ls -lF $(shell which c++ 2> /dev/null))),)
 C_FLAGS         += -Wno-self-assign
 endif
-LD_FLAGS         = -dynamiclib -install_name @rpath/lib/python$(PYTHON_SHORT_VERSION)/_$(INTERFACE:.i=.so) -Wl,-rpath,@loader_path/../.. -compatibility_version 1.0 -current_version 1.0.0 -mmacosx-version-min=$(MACOSX_MIN_SDK_VERSION) -stdlib=libc++
+LD_FLAGS         = -dynamiclib -install_name @rpath/lib/python$(PYTHON_SHORT_VERSION)/_$(INTERFACE:.i=.so) -Wl,-rpath,@loader_path/../../../../../.. -compatibility_version 1.0 -current_version 1.0.0 -mmacosx-version-min=$(MACOSX_MIN_SDK_VERSION) -stdlib=libc++
 PYTHON_INCLUDES  = -I$(PYTHON_PATH)/include/python$(PYTHON_VERSION)$(PYTHON_PYMALLOC)
 LIB             += -L"$(WEBOTS_HOME)/lib" -lController -lCppController -L"$(PYTHON_PATH)/lib" -lpython$(PYTHON_VERSION)
 LIBRARY          = $(PYTHON_LIB_FOLDER)/_$(MODULE_NAME).so

--- a/projects/robots/robotis/darwin-op/libraries/python/Makefile
+++ b/projects/robots/robotis/darwin-op/libraries/python/Makefile
@@ -15,28 +15,32 @@
 space :=
 space +=
 WEBOTS_HOME_PATH=$(subst $(space),\ ,$(strip $(subst \,/,$(WEBOTS_HOME))))
+WEBOTS_HOME_PATH_NO_ESCAPE=$(subst \,/,$(WEBOTS_HOME))
 include $(WEBOTS_HOME_PATH)/resources/Makefile.os.include
 
-MODULE_NAME = managers
 PYTHON_COMMAND ?= python
 PYTHON_VERSION := $(shell $(PYTHON_COMMAND) --version 2>&1 | sed 's/.* \([0-9]\).\([0-9]\).*/\1.\2/')
 PYTHON_SHORT_VERSION = $(subst .,,$(PYTHON_VERSION))
+PYTHON_FULL_VERSION := $(subst Python ,,$(shell $(PYTHON_COMMAND) --version 2>&1))
+PYTHON_LIB_FOLDER = ../python$(PYTHON_SHORT_VERSION)
+#WEBOTS_LIBRARY = 1
+MODULE_NAME = managers
 
 INTERFACE          = $(MODULE_NAME).i
-SOURCE_HEADERS     = $(wildcard ../managers/include/*.hpp)
-SWIG               = swig
-SWIG_OPTS          = -c++ -python -outdir "." -I"$(WEBOTS_HOME)/resources/languages/python"
+SOURCE_HEADERS     = $(substr $(WEBOTS_HOME_PATH_NO_ESCAPE),$(WEBOTS_HOME_PATH),$(wildcard $(WEBOTS_HOME_PATH)/include/controller/cpp/webots/*.hpp))
+SWIG_OPTS          = -c++ -python -outdir $(PYTHON_LIB_FOLDER) -I$(WEBOTS_HOME_PATH)/resources/languages/python/
 WRAPPER            = $(MODULE_NAME)$(PYTHON_SHORT_VERSION).cpp
 WRAPPER_OBJECT     = $(WRAPPER:.cpp=.o)
-PYOUT              = $(MODULE_NAME).py
-INCLUDES           = -I"../managers/include" -I"$(WEBOTS_HOME)/include/controller/c" -I"$(WEBOTS_HOME)/include/controller/cpp"
+PYOUT              = $(PYTHON_LIB_FOLDER)/$(MODULE_NAME).py
+INCLUDES           = -I"../managers/include" -I$(WEBOTS_HOME_PATH)/include/controller/c -I$(WEBOTS_HOME_PATH)/include/controller/cpp
 LIB                = -L"../managers" -lmanagers
 
 ifeq ($(OSTYPE),linux)
 C_FLAGS         = -c -Wall -fPIC -Wno-unused-but-set-variable
 LD_FLAGS        = -shared
-LIBRARY         = _$(MODULE_NAME).so
+LIBRARY         = $(PYTHON_LIB_FOLDER)/_$(MODULE_NAME).so
 PYTHON_INCLUDES = -I"/usr/include/python$(PYTHON_VERSION)"
+LIB            += -L"$(WEBOTS_HOME)/lib" -lController -lCppController
 endif
 
 ifeq ($(OSTYPE),windows)
@@ -45,32 +49,41 @@ SPACE          +=
 PYTHON_HOME    := $(subst \ ,$(SPACE),$(dir $(subst $(SPACE),\ ,$(shell which python 2> /dev/null))))
 C_FLAGS         = -c -O -Wall -DMS_WIN64 -D_hypot=hypot -Wno-stringop-truncation
 LD_FLAGS        = -shared -Wl,--enable-auto-import
-LIBRARY         = _$(MODULE_NAME).pyd
+LIBRARY         = $(PYTHON_LIB_FOLDER)/_$(MODULE_NAME).pyd
 PYTHON_INCLUDES = -I"$(PYTHON_HOME)include"
-LIB            += -L"$(PYTHON_HOME)libs" -lpython$(PYTHON_SHORT_VERSION)
+LIB            += -L"$(WEBOTS_HOME)/msys64/mingw64/bin" -lController -lCppController -L"$(PYTHON_HOME)libs" -lpython$(PYTHON_SHORT_VERSION)
 endif
 
 ifeq ($(OSTYPE),darwin)
-
+ifeq ($(PYTHON_SHORT_VERSION), 27)
 PYTHON_PATH ?= /System/Library/Frameworks/Python.framework/Versions/$(PYTHON_VERSION)
-
-C_FLAGS         = -c -Wall -fPIC -mmacosx-version-min=$(MACOSX_MIN_SDK_VERSION) -stdlib=libc++
-ifeq ($(findstring llvm-g++,$(shell ls -lF $(shell which c++ 2> /dev/null))),)
-C_FLAGS        += -Wno-self-assign
+PYTHON_PYMALLOC =
+else
+PYTHON_PATH ?= /Library/Frameworks/Python.framework/Versions/$(PYTHON_VERSION)
+PYTHON_PYMALLOC = m
 endif
-LD_FLAGS        = -dynamiclib -install_name @rpath/lib/python/_$(INTERFACE:.i=.so) -Wl,-rpath,@loader_path/../../../../../.. -compatibility_version 1.0 -current_version 1.0.0 -mmacosx-version-min=$(MACOSX_MIN_SDK_VERSION) -stdlib=libc++
-PYTHON_INCLUDES = -I$(PYTHON_PATH)/include/python$(PYTHON_VERSION)
-LIB            += -L"$(PYTHON_PATH)/lib" -lpython$(PYTHON_VERSION)
-LIBRARY         = _$(MODULE_NAME).so
+BREW_PYTHON_PATH = /usr/local/Cellar/python/$(PYTHON_FULL_VERSION)/Frameworks/Python.framework/Versions/$(PYTHON_VERSION)
+C_FLAGS          = -c -Wall -fPIC -mmacosx-version-min=$(MACOSX_MIN_SDK_VERSION) -stdlib=libc++
+ifeq ($(findstring llvm-g++,$(shell ls -lF $(shell which c++ 2> /dev/null))),)
+C_FLAGS         += -Wno-self-assign
+endif
+LD_FLAGS         = -dynamiclib -install_name @rpath/lib/python$(PYTHON_SHORT_VERSION)/_$(INTERFACE:.i=.so) -Wl,-rpath,@loader_path/../.. -compatibility_version 1.0 -current_version 1.0.0 -mmacosx-version-min=$(MACOSX_MIN_SDK_VERSION) -stdlib=libc++
+PYTHON_INCLUDES  = -I$(PYTHON_PATH)/include/python$(PYTHON_VERSION)$(PYTHON_PYMALLOC)
+LIB             += -L"$(WEBOTS_HOME)/lib" -lController -lCppController -L"$(PYTHON_PATH)/lib" -lpython$(PYTHON_VERSION)
+LIBRARY          = $(PYTHON_LIB_FOLDER)/_$(MODULE_NAME).so
+ifneq (,$(wildcard $(BREW_PYTHON_PATH)))
+PYTHON_INCLUDES += -I"$(BREW_PYTHON_PATH)/include/python$(PYTHON_VERSION)$(PYTHON_PYMALLOC)"
+LIB             += -L"$(BREW_PYTHON_PATH)/lib"
+endif
 endif
 
 TARGET = $(PYOUT) $(LIBRARY)
 
-SWIG_EXISTS = $(shell which $(SWIG) 2> /dev/null)
+SWIG_EXISTS = $(shell which swig 2> /dev/null)
 
 ifeq (, $(shell which $(PYTHON_COMMAND) 2> /dev/null))
 release debug profile:
-	@echo -e "# \033[0;33m$(PYTHON_COMMAND) not installed, skipping Python API\033[0m"
+	@echo -e "# \033[0;33mPython not installed, skipping Python API\033[0m"
 else ifeq ($(SWIG_EXISTS),)
 release debug profile:
 	@echo -e "# \033[0;33mSWIG not installed, skipping Python API\033[0m"
@@ -78,7 +91,7 @@ else
 release debug profile: $(TARGET)
 
 $(PYOUT) $(WRAPPER):$(INTERFACE) $(SOURCE_HEADERS)
-	$(SWIG) $(SWIG_OPTS) $(INCLUDES) -o $(WRAPPER) $<
+	swig $(SWIG_OPTS) $(INCLUDES) -o $(WRAPPER) $<
 
 $(LIBRARY):$(WRAPPER_OBJECT)
 	$(CXX) $(LD_FLAGS) $< $(DEF) $(LIB) -o "$@"
@@ -88,4 +101,4 @@ $(WRAPPER_OBJECT):$(WRAPPER)
 endif
 
 clean:
-	@rm -fr *.o *.cpp $(PYOUT) $(LIBRARY) $(MODULE_NAME).pyc __pycache__
+	@rm -fr *.o *.cpp $(PYOUT) $(LIBRARY) $(MODULE_NAME).pyc

--- a/projects/robots/robotis/darwin-op/libraries/python27/.gitignore
+++ b/projects/robots/robotis/darwin-op/libraries/python27/.gitignore
@@ -1,0 +1,3 @@
+/managers??.cpp
+/managers.py
+/_managers.pyd

--- a/projects/robots/robotis/darwin-op/libraries/python27/.gitignore
+++ b/projects/robots/robotis/darwin-op/libraries/python27/.gitignore
@@ -1,3 +1,1 @@
-/managers??.cpp
 /managers.py
-/_managers.pyd

--- a/projects/robots/robotis/darwin-op/libraries/python35/.gitignore
+++ b/projects/robots/robotis/darwin-op/libraries/python35/.gitignore
@@ -1,0 +1,3 @@
+/managers??.cpp
+/managers.py
+/_managers.pyd

--- a/projects/robots/robotis/darwin-op/libraries/python35/.gitignore
+++ b/projects/robots/robotis/darwin-op/libraries/python35/.gitignore
@@ -1,3 +1,1 @@
-/managers??.cpp
 /managers.py
-/_managers.pyd

--- a/projects/robots/robotis/darwin-op/libraries/python36/.gitignore
+++ b/projects/robots/robotis/darwin-op/libraries/python36/.gitignore
@@ -1,0 +1,3 @@
+/managers??.cpp
+/managers.py
+/_managers.pyd

--- a/projects/robots/robotis/darwin-op/libraries/python36/.gitignore
+++ b/projects/robots/robotis/darwin-op/libraries/python36/.gitignore
@@ -1,3 +1,1 @@
-/managers??.cpp
 /managers.py
-/_managers.pyd

--- a/projects/robots/robotis/darwin-op/libraries/python37/.gitignore
+++ b/projects/robots/robotis/darwin-op/libraries/python37/.gitignore
@@ -1,0 +1,3 @@
+/managers??.cpp
+/managers.py
+/_managers.pyd

--- a/projects/robots/robotis/darwin-op/libraries/python37/.gitignore
+++ b/projects/robots/robotis/darwin-op/libraries/python37/.gitignore
@@ -1,3 +1,1 @@
-/managers??.cpp
 /managers.py
-/_managers.pyd

--- a/projects/samples/robotbenchmark/humanoid_marathon/controllers/marathon/marathon.py
+++ b/projects/samples/robotbenchmark/humanoid_marathon/controllers/marathon/marathon.py
@@ -6,13 +6,10 @@ import os
 import sys
 from controller import Robot
 
-# Path operations to correctly locate the managers.
-if sys.version_info.major > 2:
-    sys.exit("RobotisOpManager library is available only for Python 2.7")
-
 try:
+    pythonVersion = 'python%d%d' % (sys.version_info[0], sys.version_info[1])
     libraryPath = os.path.join(os.environ.get("WEBOTS_HOME"), 'projects', 'robots', 'robotis', 'darwin-op', 'libraries',
-                               'python')
+                               pythonVersion)
     libraryPath = libraryPath.replace('/', os.sep)
     sys.path.append(libraryPath)
     from managers import RobotisOp2GaitManager, RobotisOp2MotionManager


### PR DESCRIPTION
Fix:
  - [x] Compile the vehicle library for python 3.7 on linux
  - [x] Compile the RobotisOpManager library for python 3.x (#520)