### PR TITLE
Fix openVR includes installation.

### DIFF
--- a/dependencies/Makefile.windows
+++ b/dependencies/Makefile.windows
@@ -59,7 +59,7 @@ open-vr-clean:
 open-vr: $(TARGET_PATH)/openvr_api.dll $(WEBOTS_HOME_PATH)/include/openvr
 
 $(WEBOTS_HOME_PATH)/include/openvr: $(WEBOTS_DEPENDENCY_PATH)/openvr-1.0.7
-	cp -rf "$(WEBOTS_DEPENDENCY_PATH)"/openvr-1.0.7/headers "$(WEBOTS_HOME_PATH)/include/openvr"
+	cp -f "$(WEBOTS_DEPENDENCY_PATH)"/openvr-1.0.7/headers/* "$(WEBOTS_HOME_PATH)/include/openvr"
 
 $(TARGET_PATH)/openvr_api.dll: $(WEBOTS_DEPENDENCY_PATH)/openvr-1.0.7
 	mkdir -p $(TARGET_PATH)


### PR DESCRIPTION
The includes were copied into `include/openvr/headers/*.h` instead of `include/openvr/*.h`.