### PR TITLE
Fix Makefile call order

### DIFF
--- a/dependencies/Makefile.mac
+++ b/dependencies/Makefile.mac
@@ -213,7 +213,7 @@ $(WEBOTS_DEPENDENCY_PATH)/openssl-1.0.2:
 
 
 pico-clean:
-	rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)$(WEBOTS_HOME)/include/libpico $(WEBOTS_HOME)/lib/libpico.dylib $(WEBOTS_HOME)/resources/pico
+	rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE) $(WEBOTS_HOME)/include/libpico $(WEBOTS_HOME)/lib/libpico.dylib $(WEBOTS_HOME)/resources/pico
 
 pico: $(WEBOTS_HOME)/lib/libpico.dylib
 

--- a/projects/Makefile
+++ b/projects/Makefile
@@ -16,8 +16,6 @@ ifeq ($(WEBOTS_HOME),)
 WEBOTS_HOME_ARG=WEBOTS_HOME=$(shell cd .. ; pwd)
 endif
 
-cleanse: clean
-
 release profile debug clean:
 	@echo "#"; echo "# !!! languages !!!"
 	@+make -s -C languages $@ $(WEBOTS_HOME_ARG)
@@ -31,3 +29,5 @@ release profile debug clean:
 	@+make -s -C samples $@ $(WEBOTS_HOME_ARG)
 	@echo "#"; echo "# !!! vehicles !!!"
 	@+make -s -C vehicles $@ $(WEBOTS_HOME_ARG)
+
+cleanse: clean

--- a/projects/default/Makefile
+++ b/projects/default/Makefile
@@ -37,7 +37,7 @@ controllers/%.Makefile libraries/%.Makefile: $(ROS_DEPENDENCIES)
 	+@echo "# make" $(MAKECMDGOALS) $(@:.Makefile=)
 	+@make -s -C $(@:.Makefile=) $(MAKECMDGOALS)
 
-%.Makefile controllers/ros/%.Makefile:
+$(ROS_DEPENDENCIES):
 	+@echo "# make" $(MAKECMDGOALS) $(@:.Makefile=)
 	+@make -s -C $(@:.Makefile=) $(MAKECMDGOALS)
 


### PR DESCRIPTION
- [x] Fix Makefile call order: ROS libraries download may occur after the ROS controller build on mac
- [x] Fix `make` call on the `./projects` directory which cleans instead of build: `cleanse` should never be the first rule.
- [x] Fix the pico rule of `cleanse` on macOS