### PR TITLE
Update Makefile.windows

### DIFF
--- a/dependencies/Makefile.windows
+++ b/dependencies/Makefile.windows
@@ -59,6 +59,7 @@ open-vr-clean:
 open-vr: $(TARGET_PATH)/openvr_api.dll $(WEBOTS_HOME_PATH)/include/openvr
 
 $(WEBOTS_HOME_PATH)/include/openvr: $(WEBOTS_DEPENDENCY_PATH)/openvr-1.0.7
+	mkdir "$(WEBOTS_HOME_PATH)/include/openvr"
 	cp -f "$(WEBOTS_DEPENDENCY_PATH)"/openvr-1.0.7/headers/* "$(WEBOTS_HOME_PATH)/include/openvr"
 
 $(TARGET_PATH)/openvr_api.dll: $(WEBOTS_DEPENDENCY_PATH)/openvr-1.0.7
@@ -71,7 +72,6 @@ $(WEBOTS_DEPENDENCY_PATH)/openvr-1.0.7:
 	unzip -o "$(WEBOTS_DEPENDENCY_PATH)/$(OPEN_VR_PACKAGE)" -d "$(WEBOTS_DEPENDENCY_PATH)"
 	rm -f "$(WEBOTS_DEPENDENCY_PATH)/$(OPEN_VR_PACKAGE)"
 	touch "$(WEBOTS_DEPENDENCY_PATH)/openvr-1.0.7"
-	mkdir "$(WEBOTS_HOME_PATH)/include/openvr"
 
 lua-clean:
 	rm -rf $(TARGET_PATH)/lua52.dll "$(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3"


### PR DESCRIPTION
#558 was still not perfect, because in some case as the `$(TARGET_PATH)/openvr_api.dll` rule create the `$(WEBOTS_HOME_PATH)/include/openvr` directory, the `$(WEBOTS_HOME_PATH)/include/openvr` rule was not called.