### PR TITLE
Make travis per commit tests on one platform only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,10 @@ jobs:
         - if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then python tests/sources/generate_diff.py $TRAVIS_BRANCH; fi
         - travis_wait 30 python -m unittest discover -s tests/sources
     - <<: *source_tests_staging
+      if: type = cron OR commit_message IN (travis_sources, travis_unit, travis_distrib, travis_deploy)
       python: '2.7'
     - <<: *source_tests_staging
+      if: type = cron OR commit_message IN (travis_sources, travis_unit, travis_distrib, travis_deploy)
       os: osx
       osx_image: xcode10.2  # Xcode: 10.2.1  |  macOS: 10.14
       language: generic     # Travis doesn't support python on macos yet


### PR DESCRIPTION
The goal of this PR is to test on linux-python27 and mac only during the nightly build or if triggered with the `travis_sources` keyword).