### PR TITLE
Fix Robotis library "make clean" rule

### DIFF
--- a/projects/robots/robotis/darwin-op/libraries/Makefile
+++ b/projects/robots/robotis/darwin-op/libraries/Makefile
@@ -31,7 +31,8 @@ release debug profile: $(TARGETS)
 	cp python27/*managers.* python  # kept for backward compatibility with < R2019b
 
 clean: $(TARGETS)
-	rm -rf python/*managers.*
+	# Remove python/*managers.* except python/managers.i
+	ls -1 python/*managers.* | grep -v managers.i | xargs rm
 
 managers.Makefile: robotis-op2.Makefile
 


### PR DESCRIPTION
`projects/robots/robotis/darwin-op/libraries/python/managers.i` is wrongly removed during a `make clean`.