### PR TITLE
macOS Fix crash on startup

### DIFF
--- a/src/ode/Makefile
+++ b/src/ode/Makefile
@@ -40,6 +40,9 @@ else ifeq ($(MAKECMDGOALS),install)
 $(TARGET_ODE_LIBRARY):
 	@echo "#" copying $(@F) to $@
 	@cp $(@F) $@
+ifeq ($(OSTYPE),darwin)
+	@install_name_tool -id @rpath/lib/libode.dylib $@
+endif
 
 install: $(TARGET_ODE_LIBRARY)
 


### PR DESCRIPTION
Due to our recent modifications on the libode build, the RPATH in libode was wrong causing a crash on the Webots statup when installed from a package.
