### PR TITLE
Fix warning about deprecated wallTileSize in camera_auto_focus

### DIFF
--- a/projects/samples/devices/worlds/camera_auto_focus.wbt
+++ b/projects/samples/devices/worlds/camera_auto_focus.wbt
@@ -16,7 +16,6 @@ TexturedBackgroundLight {
 RectangleArena {
   floorTileSize 0.25 0.25
   wallHeight 0.15
-  wallTileSize 0.1 0.1
   wallAppearance PBRAppearance {
     baseColorMap ImageTexture {
       url [


### PR DESCRIPTION
The warning is:

```
ERROR: 'RectangleArena.proto': Lua error: The 'wallTileSize' field is deprecated, using the new 'wallApperance' field instead.
```