### PR TITLE
Fix various warning and errors in worlds.

### DIFF
--- a/projects/robots/k-team/hemisson/worlds/hemisson.wbt
+++ b/projects/robots/k-team/hemisson/worlds/hemisson.wbt
@@ -25,7 +25,6 @@ RectangleArena {
     roughness 1
     metalness 0
   }
-  wallColor 1 0 0
   wallTextureUrl []
 }
 DEF RED_BRICK Solid {

--- a/projects/robots/k-team/khepera1/worlds/khepera_k213.wbt
+++ b/projects/robots/k-team/khepera1/worlds/khepera_k213.wbt
@@ -15,8 +15,7 @@ TexturedBackgroundLight {
 }
 RectangleArena {
   floorSize 0.98 0.98
-  wallHeight 0.020000000000000004
-  wallColor 1 0.1 0.3
+  wallHeight 0.02
   wallTextureUrl []
 }
 DEF BOX Solid {

--- a/projects/samples/howto/worlds/center_of_mass.wbt
+++ b/projects/samples/howto/worlds/center_of_mass.wbt
@@ -208,6 +208,7 @@ Robot {
       ]
     }
   ]
+  name "robot(1)"
   boundingObject USE GROUP
   physics Physics {
   }

--- a/projects/samples/robotbenchmark/square_path/worlds/square_path.wbt
+++ b/projects/samples/robotbenchmark/square_path/worlds/square_path.wbt
@@ -45,7 +45,6 @@ RectangleArena {
     metalness 0
   }
   wallHeight 0.5
-  wallTileSize 1 1
   wallAppearance PBRAppearance {
     baseColorMap ImageTexture {
       url [

--- a/projects/samples/tutorials/worlds/obstacles.wbt
+++ b/projects/samples/tutorials/worlds/obstacles.wbt
@@ -31,7 +31,8 @@ WoodenBox {
   rotation 0 -1 0 0.34688418883387256
   name "wooden box(2)"
   size 0.1 0.1 0.1
-mass 0.2
+  mass 0.2
+}
 E-puck {
   controller "e-puck_go_forward"
 }


### PR DESCRIPTION
The `test_world_warnings` test report errors in the following worlds:
  - projects/samples/howto/worlds/center_of_mass.wbt
  - projects/samples/tutorials/worlds/obstacles.wbt
  - projects/samples/robotbenchmark/square_path/worlds/square_path.wbt
  - projects/samples/devices/worlds/led.wbt (fixed in #593)
  - projects/samples/devices/worlds/camera_auto_focus.wbt (fixed in #594)
  - projects/robots/k-team/hemisson/worlds/hemisson.wbt
  - projects/robots/k-team/khepera1/worlds/khepera_k213.wbt