### PR TITLE
Added missing DLL needed by GCC 9.1.0

### DIFF
--- a/src/packaging/files_msys64.txt
+++ b/src/packaging/files_msys64.txt
@@ -24,6 +24,7 @@
 /mingw64/bin/libsqlite3-0.dll
 /mingw64/bin/libxslt-1.dll
 /mingw64/bin/libcrypto-1_1-x64.dll
+/mingw64/bin/libdouble-conversion.dll
 /mingw64/bin/libjpeg-8.dll
 /mingw64/bin/libpng16-16.dll
 /mingw64/bin/libfreetype-6.dll


### PR DESCRIPTION
Since the upgrade to gcc 9.1.0, this DLL is now a dependency of Webots (and probably of other binaries built with gcc 9.1.0).

👍 