### PR TITLE
Fix Nightly Version in Splash Screen

### DIFF
--- a/src/webots/gui/WbSplashScreen.cpp
+++ b/src/webots/gui/WbSplashScreen.cpp
@@ -73,7 +73,7 @@ void WbSplashScreen::drawContents(QPainter *painter) {
   font = QFont("Raleway Light", 30 * dotsPerInchRatio);
   painter->setFont(font);
   painter->setPen(versionColor());
-  painter->drawText(QRect(0, 273, 380, 100), Qt::AlignCenter, WbApplicationInfo::version().toString(true, false, true));
+  painter->drawText(QRect(0, 273, 380, 100), Qt::AlignCenter, WbApplicationInfo::version().toString(true, false, false));
 
   // then draw updating text
   font = QFont("Helvetica", 10 * dotsPerInchRatio);


### PR DESCRIPTION
We should not show the commit ID in the splash screen:
![Capture_decran_2019-06-19_a_14 04 44](https://user-images.githubusercontent.com/2461619/59765304-15d0bc00-929e-11e9-80b9-b5659caae6c6.png)
