### PR TITLE
Fix camera_noise_mask to render more easy the red blob detection

### DIFF
--- a/projects/samples/devices/worlds/camera.wbt
+++ b/projects/samples/devices/worlds/camera.wbt
@@ -15,9 +15,10 @@ TexturedBackgroundLight {
 }
 RectangleArena {
 }
-DirectionalLight {
-  direction 1 -1 -1
-  intensity 0.4
+PointLight {
+  attenuation 0 0 1
+  intensity 0.6
+  location 0 0.6 0
 }
 DEF GREEN_BOX Solid {
   translation -0.05 0.05 -0.25
@@ -36,7 +37,7 @@ DEF GREEN_BOX Solid {
   name "green box"
   boundingObject Shape {
     appearance PBRAppearance {
-      roughness 1.1102230246251565e-16
+      roughness 0
       metalness 0
     }
     geometry USE BOX0
@@ -53,14 +54,14 @@ DEF BLUE_BOX Solid {
         metalness 0
       }
       geometry DEF BOX1 Box {
-        size 0.1 0.1 0.1
+        size 0.2 0.1 0.1
       }
     }
   ]
   name "blue box"
   boundingObject Shape {
     appearance PBRAppearance {
-      roughness 1.1102230246251565e-16
+      roughness 0
       metalness 0
     }
     geometry USE BOX1
@@ -84,7 +85,7 @@ DEF WHITE_BOX Solid {
   name "gray box"
   boundingObject Shape {
     appearance PBRAppearance {
-      roughness 1.1102230246251565e-16
+      roughness 0
       metalness 0
     }
     geometry USE BOX2
@@ -92,6 +93,7 @@ DEF WHITE_BOX Solid {
 }
 DEF RED_BOX Solid {
   translation 0.42 0.05 -0.1
+  rotation 0 1 0 1.8325996938995748
   children [
     Shape {
       appearance PBRAppearance {
@@ -100,14 +102,14 @@ DEF RED_BOX Solid {
         metalness 0
       }
       geometry DEF BOX3 Box {
-        size 0.15 0.1 0.08
+        size 0.2 0.1 0.08
       }
     }
   ]
   name "red box"
   boundingObject Shape {
     appearance PBRAppearance {
-      roughness 1.1102230246251565e-16
+      roughness 0
       metalness 0
     }
     geometry USE BOX3

--- a/projects/samples/devices/worlds/camera_motion_blur.wbt
+++ b/projects/samples/devices/worlds/camera_motion_blur.wbt
@@ -15,6 +15,11 @@ TexturedBackgroundLight {
 }
 RectangleArena {
 }
+PointLight {
+  attenuation 0 0 1
+  intensity 0.6
+  location 0 0.6 0
+}
 DEF GREEN_BOX Solid {
   translation -0.05 0.05 -0.25
   children [
@@ -32,7 +37,7 @@ DEF GREEN_BOX Solid {
   name "green box"
   boundingObject Shape {
     appearance PBRAppearance {
-      roughness 1.1102230246251565e-16
+      roughness 0
       metalness 0
     }
     geometry USE BOX0
@@ -49,14 +54,14 @@ DEF BLUE_BOX Solid {
         metalness 0
       }
       geometry DEF BOX1 Box {
-        size 0.1 0.1 0.1
+        size 0.2 0.1 0.1
       }
     }
   ]
   name "blue box"
   boundingObject Shape {
     appearance PBRAppearance {
-      roughness 1.1102230246251565e-16
+      roughness 0
       metalness 0
     }
     geometry USE BOX1
@@ -80,30 +85,31 @@ DEF WHITE_BOX Solid {
   name "gray box"
   boundingObject Shape {
     appearance PBRAppearance {
-      roughness 1.1102230246251565e-16
+      roughness 0
       metalness 0
     }
     geometry USE BOX2
   }
 }
-DEF PINK_BOX Solid {
+DEF RED_BOX Solid {
   translation 0.42 0.05 -0.1
+  rotation 0 1 0 1.8325996938995748
   children [
     Shape {
       appearance PBRAppearance {
-        baseColor 1 0.1 0.3
+        baseColor 1 0 0
         roughness 0.16827074099999995
         metalness 0
       }
       geometry DEF BOX3 Box {
-        size 0.15 0.1 0.08
+        size 0.2 0.1 0.08
       }
     }
   ]
   name "red box"
   boundingObject Shape {
     appearance PBRAppearance {
-      roughness 1.1102230246251565e-16
+      roughness 0
       metalness 0
     }
     geometry USE BOX3

--- a/projects/samples/devices/worlds/camera_noise_mask.wbt
+++ b/projects/samples/devices/worlds/camera_noise_mask.wbt
@@ -13,6 +13,11 @@ TexturedBackground {
 }
 TexturedBackgroundLight {
 }
+PointLight {
+  attenuation 0 0 1
+  intensity 0.6
+  location 0 0.6 0
+}
 RectangleArena {
 }
 DEF GREEN_BOX Solid {
@@ -86,12 +91,13 @@ DEF WHITE_BOX Solid {
     geometry USE BOX2
   }
 }
-DEF PINK_BOX Solid {
+DEF RED_BOX Solid {
   translation 0.42 0.05 -0.1
+  rotation 0 1 0 1.8325996938995748
   children [
     Shape {
       appearance PBRAppearance {
-        baseColor 1 0.1 0.3
+        baseColor 1 0 0
         roughness 0.16827074099999995
         metalness 0
       }

--- a/projects/samples/devices/worlds/camera_noise_mask.wbt
+++ b/projects/samples/devices/worlds/camera_noise_mask.wbt
@@ -13,12 +13,12 @@ TexturedBackground {
 }
 TexturedBackgroundLight {
 }
+RectangleArena {
+}
 PointLight {
   attenuation 0 0 1
   intensity 0.6
   location 0 0.6 0
-}
-RectangleArena {
 }
 DEF GREEN_BOX Solid {
   translation -0.05 0.05 -0.25
@@ -37,7 +37,7 @@ DEF GREEN_BOX Solid {
   name "green box"
   boundingObject Shape {
     appearance PBRAppearance {
-      roughness 1.1102230246251565e-16
+      roughness 0
       metalness 0
     }
     geometry USE BOX0
@@ -54,14 +54,14 @@ DEF BLUE_BOX Solid {
         metalness 0
       }
       geometry DEF BOX1 Box {
-        size 0.1 0.1 0.1
+        size 0.2 0.1 0.1
       }
     }
   ]
   name "blue box"
   boundingObject Shape {
     appearance PBRAppearance {
-      roughness 1.1102230246251565e-16
+      roughness 0
       metalness 0
     }
     geometry USE BOX1
@@ -85,7 +85,7 @@ DEF WHITE_BOX Solid {
   name "gray box"
   boundingObject Shape {
     appearance PBRAppearance {
-      roughness 1.1102230246251565e-16
+      roughness 0
       metalness 0
     }
     geometry USE BOX2
@@ -102,14 +102,14 @@ DEF RED_BOX Solid {
         metalness 0
       }
       geometry DEF BOX3 Box {
-        size 0.15 0.1 0.08
+        size 0.2 0.1 0.08
       }
     }
   ]
   name "red box"
   boundingObject Shape {
     appearance PBRAppearance {
-      roughness 1.1102230246251565e-16
+      roughness 0
       metalness 0
     }
     geometry USE BOX3


### PR DESCRIPTION
Fix #609 

Since R2018b, an HDR background has been added to this world, changing the global light, and render more difficult the red blob detection.

I added a central light, change the pink color of this block to red, and increase the blob surface by rotating slightly the block. Should be much more robust now.

<img width="1438" alt="camera_red_blob" src="https://user-images.githubusercontent.com/866788/59769553-ad3a0d00-92a6-11e9-85c1-0bc3d0c78484.png">