### PR TITLE
Always use 'play' in cookie storing the animation status

### DIFF
--- a/resources/web/wwi/animation.js
+++ b/resources/web/wwi/animation.js
@@ -24,6 +24,10 @@ class Animation { // eslint-disable-line no-unused-vars
     xmlhttp.send();
   }
 
+  getStatus() {
+    return this.gui === 'real_time' ? 'play' : 'pause';
+  }
+
   // private methods
   _setup(data) {
     this.data = data;

--- a/resources/web/wwi/animation.js
+++ b/resources/web/wwi/animation.js
@@ -26,6 +26,7 @@ class Animation { // eslint-disable-line no-unused-vars
 
   // Return the animation status: play or pause.
   // This should be used to store the current animation status and restore it later when calling webots.View.setAnimation().
+  // This is for example used in robotbenchmark.net benchmark page.
   getStatus() {
     return this.gui === 'real_time' ? 'play' : 'pause';
   }

--- a/resources/web/wwi/animation.js
+++ b/resources/web/wwi/animation.js
@@ -24,6 +24,8 @@ class Animation { // eslint-disable-line no-unused-vars
     xmlhttp.send();
   }
 
+  // Return the animation status: play or pause.
+  // This should be used to store the current animation status and restore it later when calling webots.View.setAnimation.
   getStatus() {
     return this.gui === 'real_time' ? 'play' : 'pause';
   }

--- a/resources/web/wwi/animation.js
+++ b/resources/web/wwi/animation.js
@@ -25,7 +25,7 @@ class Animation { // eslint-disable-line no-unused-vars
   }
 
   // Return the animation status: play or pause.
-  // This should be used to store the current animation status and restore it later when calling webots.View.setAnimation.
+  // This should be used to store the current animation status and restore it later when calling webots.View.setAnimation().
   getStatus() {
     return this.gui === 'real_time' ? 'play' : 'pause';
   }


### PR DESCRIPTION
Previously `this.gui` was supporting the values `play` and `pause`, but when changing the icon from `play.png` to `real_time.png`,  `play` is internally converted to `real_time` in animation.js.
In order to keep compatibility and given that `play` is more descriptive it is good to continue using it from outside the Animation class.

This PR adds a function to return the status of the Animation and convert back `real_time` to `play`, needed on robotbenchmark to store the animation status in the `animation_gui` cookie.
