### PR TITLE
Bloom in webots.min.js

### DIFF
--- a/change_logs/ChangeLog.html
+++ b/change_logs/ChangeLog.html
@@ -9,7 +9,20 @@
 
 <h1>Webots change log</h1>
 
-<h2><a href='https://cyberbotics.com/doc/blog/Webots-2018-b-release'>Webots R2019b</a></h2>
+<h2><a href='https://cyberbotics.com/doc/blog/Webots-2020-a-release'>Webots R2020a</a></h2>
+Released on December ??th, 2019
+
+<ul>
+<li><b>New Features</b></li>
+<ul>
+<li>Improved the Webots online 3D viewer: 'webots.min.js'</li>
+<ul>
+<li>Improved support of the Webots rendering pipeline: supported the Bloom post-processing effect.</li>
+</ul>
+</ul>
+</ul>
+
+<h2><a href='https://cyberbotics.com/doc/blog/Webots-2019-b-release'>Webots R2019b</a></h2>
 Released on June 25th, 2019
 
 <ul>

--- a/resources/web/wwi/Makefile
+++ b/resources/web/wwi/Makefile
@@ -70,18 +70,23 @@ INSTALL_TOKEN = install.token
 NPM_EXISTS = $(shell which npm 2> /dev/null)
 
 ifeq ($(NPM_EXISTS),)
-release debug profile update:
+release profile update:
 	@echo "# Please install nodejs to build 'webots.min.js' using the instructions on the GitHub wiki."
 else
-release debug profile update: webots.min.js
+release profile update: webots.min.js
 endif
+debug: webots.debug.js
 
 webots.min.js: $(JS_SOURCES) $(LOCAL_THREEJS_EXAMPLE_SOURCES) $(THREEJS_SOURCE) $(INSTALL_TOKEN)
 	@echo "# compressing webots.min.js"
-	node_modules/.bin/babel $(LOCAL_THREEJS_EXAMPLE_SOURCES) $(JS_SOURCES) $(BABEL_JS_SOURCES) -o webots.tmp1.js --presets "@babel/preset-env"
+	@node_modules/.bin/babel $(LOCAL_THREEJS_EXAMPLE_SOURCES) $(JS_SOURCES) $(BABEL_JS_SOURCES) -o webots.tmp1.js --presets "@babel/preset-env"
 	@cat $(THREEJS_SOURCE) webots.tmp1.js > webots.tmp2.js
-	@node_modules/.bin/minify webots.tmp2.js -o webots.min.js
+	@node_modules/.bin/minify webots.tmp2.js -o $@
 	@rm webots.tmp2.js webots.tmp1.js
+
+webots.debug.js: $(JS_SOURCES) $(LOCAL_THREEJS_EXAMPLE_SOURCES) $(THREEJS_SOURCE) $(INSTALL_TOKEN)
+	@echo "# creating webots.debug.js"
+	@cat $(THREEJS_SOURCE) $(LOCAL_THREEJS_EXAMPLE_SOURCES) $(JS_SOURCES) $(BABEL_JS_SOURCES) > $@
 
 $(THREEJS_SOURCE):
 	@echo "# downloading $(THREEJS_URL)"

--- a/resources/web/wwi/Makefile
+++ b/resources/web/wwi/Makefile
@@ -44,10 +44,14 @@ JS_SOURCES = \
 BABEL_JS_SOURCES = \
   node_modules/@babel/polyfill/dist/polyfill.js
 
+ifneq ($(MAKECMDGOALS),debug)
+THREEJS_SUFFIX = .min
+endif
+
 DEPENDENCIES_PATH = dependencies
 THEEEJS_VERSION = 104
-THREEJS_SOURCE = $(DEPENDENCIES_PATH)/three.min.js
-THREEJS_URL = https://cdnjs.cloudflare.com/ajax/libs/three.js/$(THEEEJS_VERSION)/three.min.js
+THREEJS_SOURCE = $(DEPENDENCIES_PATH)/three$(THREEJS_SUFFIX).js
+THREEJS_URL = https://cdnjs.cloudflare.com/ajax/libs/three.js/$(THEEEJS_VERSION)/three$(THREEJS_SUFFIX).js
 
 # external sources to be downloaded and minified
 THREEJS_EXAMPLE_URL = https://cdn.jsdelivr.net/gh/mrdoob/three.js@r$(THEEEJS_VERSION)/examples/js/

--- a/resources/web/wwi/Makefile
+++ b/resources/web/wwi/Makefile
@@ -14,6 +14,10 @@
 
 JS_SOURCES = \
   shaders/hdr_resolve.js \
+  shaders/bright_pass.js \
+  shaders/blend_bloom.js \
+  shaders/gaussian_blur_13_tap.js \
+  passes/bloom.js \
   equirectangular_to_cube_generator.js \
   gpu_picker.js \
   util.js \

--- a/resources/web/wwi/passes/bloom.js
+++ b/resources/web/wwi/passes/bloom.js
@@ -1,0 +1,226 @@
+/* global THREE */
+
+THREE.Bloom = class Bloom extends THREE.Pass {
+  constructor(resolution = new THREE.Vector2(256, 256), threshold = 21.0) {
+    super();
+
+    this.threshold = threshold;
+    this.resolution = resolution.clone();
+
+    // create color only once here, reuse it later inside the render function
+    this.clearColor = new THREE.Color(0, 0, 0);
+
+    // render targets
+    var pars = { minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter, format: THREE.RGBAFormat };
+    this.renderTargetsHorizontal = [];
+    this.renderTargetsVertical = [];
+    var resx = Math.round(this.resolution.x / 2);
+    var resy = Math.round(this.resolution.y / 2);
+
+    this.renderTargetBright = new THREE.WebGLRenderTarget(resx, resy, pars);
+    this.renderTargetBright.texture.name = 'Bloom.bright';
+    this.renderTargetBright.texture.generateMipmaps = false;
+
+    for (let i = 0; i < 6; i++) {
+      var renderTargetHorizonal = new THREE.WebGLRenderTarget(resx, resy, pars);
+
+      renderTargetHorizonal.texture.name = 'Bloom.h' + i;
+      renderTargetHorizonal.texture.generateMipmaps = false;
+
+      this.renderTargetsHorizontal.push(renderTargetHorizonal);
+
+      var renderTargetVertical = new THREE.WebGLRenderTarget(resx, resy, pars);
+
+      renderTargetVertical.texture.name = 'Bloom.v' + i;
+      renderTargetVertical.texture.generateMipmaps = false;
+
+      this.renderTargetsVertical.push(renderTargetVertical);
+
+      resx = Math.round(resx / 2);
+      resy = Math.round(resy / 2);
+    }
+
+    // luminosity high pass material
+
+    if (THREE.brightPassShader === undefined)
+      console.error('Bloom relies on THREE.brightPassShader');
+
+    var brightPassShader = THREE.brightPassShader;
+    this.brightPassUniforms = THREE.UniformsUtils.clone(brightPassShader.uniforms);
+    this.brightPassUniforms[ 'threshold' ].value = this.threshold;
+    this.brightPassUniforms[ 'textureSize' ].value = this.resolution;
+
+    this.materialBrightPass = new THREE.ShaderMaterial({
+      uniforms: this.brightPassUniforms,
+      vertexShader: brightPassShader.vertexShader,
+      fragmentShader: brightPassShader.fragmentShader,
+      defines: {}
+    });
+
+    // Gaussian Blur Materials
+    if (THREE.gaussianBlur13Tap === undefined)
+      console.error('Bloom relies on THREE.gaussianBlur13Tap');
+
+    this.separableBlurMaterials = [];
+    resx = Math.round(this.resolution.x / 2);
+    resy = Math.round(this.resolution.y / 2);
+
+    for (let i = 0; i < 6; i++) {
+      this.separableBlurMaterials.push(new THREE.ShaderMaterial(THREE.gaussianBlur13Tap));
+      this.separableBlurMaterials[ i ].uniforms[ 'texSize' ].value = new THREE.Vector2(resx, resy);
+
+      resx = Math.round(resx / 2);
+      resy = Math.round(resy / 2);
+    }
+
+    // Composite material
+    if (THREE.brightPassShader === undefined)
+      console.error('Bloom relies on THREE.blendBloomShader');
+    this.compositeMaterial = new THREE.ShaderMaterial(THREE.blendBloomShader);
+    this.compositeMaterial.uniforms[ 'blurTexture1' ].value = this.renderTargetsVertical[ 0 ].texture;
+    this.compositeMaterial.uniforms[ 'blurTexture2' ].value = this.renderTargetsVertical[ 1 ].texture;
+    this.compositeMaterial.uniforms[ 'blurTexture3' ].value = this.renderTargetsVertical[ 2 ].texture;
+    this.compositeMaterial.uniforms[ 'blurTexture4' ].value = this.renderTargetsVertical[ 3 ].texture;
+    this.compositeMaterial.uniforms[ 'blurTexture5' ].value = this.renderTargetsVertical[ 4 ].texture;
+    this.compositeMaterial.uniforms[ 'blurTexture6' ].value = this.renderTargetsVertical[ 5 ].texture;
+    this.compositeMaterial.needsUpdate = true;
+
+    // copy material
+    if (THREE.CopyShader === undefined)
+      console.error('THREE.BloomPass relies on THREE.CopyShader');
+
+    var copyShader = THREE.CopyShader;
+
+    this.copyUniforms = THREE.UniformsUtils.clone(copyShader.uniforms);
+    this.copyUniforms[ 'opacity' ].value = 1.0;
+
+    this.materialCopy = new THREE.ShaderMaterial({
+      uniforms: this.copyUniforms,
+      vertexShader: copyShader.vertexShader,
+      fragmentShader: copyShader.fragmentShader,
+      blending: THREE.AdditiveBlending,
+      depthTest: false,
+      depthWrite: false,
+      transparent: true
+    });
+
+    this.enabled = true;
+    this.needsSwap = false;
+
+    this.oldClearColor = new THREE.Color();
+    this.oldClearAlpha = 1;
+
+    this.basic = new THREE.MeshBasicMaterial();
+
+    this.fsQuad = new THREE.Pass.FullScreenQuad(null);
+  }
+
+  dispose() {
+    for (let i = 0; i < this.renderTargetsHorizontal.length; i++)
+      this.renderTargetsHorizontal[ i ].dispose();
+
+    for (let i = 0; i < this.renderTargetsVertical.length; i++)
+      this.renderTargetsVertical[ i ].dispose();
+
+    this.renderTargetBright.dispose();
+  }
+
+  setSize(width, height) {
+    var resx = Math.round(width / 2);
+    var resy = Math.round(height / 2);
+
+    this.renderTargetBright.setSize(resx, resy);
+    this.brightPassUniforms[ 'textureSize' ].value = new THREE.Vector2(width, height);
+
+    for (let i = 0; i < 6; i++) {
+      this.renderTargetsHorizontal[ i ].setSize(resx, resy);
+      this.renderTargetsVertical[ i ].setSize(resx, resy);
+
+      this.separableBlurMaterials[ i ].uniforms[ 'texSize' ].value = new THREE.Vector2(resx, resy);
+
+      resx = Math.round(resx / 2);
+      resy = Math.round(resy / 2);
+    }
+  }
+
+  render(renderer, writeBuffer, readBuffer, deltaTime, maskActive) {
+    this.oldClearColor.copy(renderer.getClearColor());
+    this.oldClearAlpha = renderer.getClearAlpha();
+    var oldAutoClear = renderer.autoClear;
+    renderer.autoClear = false;
+
+    renderer.setClearColor(this.clearColor, 0);
+
+    if (maskActive)
+      renderer.context.disable(renderer.context.STENCIL_TEST);
+
+    // Render input to screen
+    if (this.renderToScreen) {
+      this.fsQuad.material = this.basic;
+      this.basic.map = readBuffer.texture;
+
+      renderer.setRenderTarget(null);
+      renderer.clear();
+      this.fsQuad.render(renderer);
+    }
+
+    // 1. Extract Bright Areas
+
+    this.brightPassUniforms[ 'tDiffuse' ].value = readBuffer.texture;
+    this.brightPassUniforms[ 'threshold' ].value = this.threshold;
+    this.fsQuad.material = this.materialBrightPass;
+
+    renderer.setRenderTarget(this.renderTargetBright);
+    renderer.clear();
+    this.fsQuad.render(renderer);
+
+    // 2. Blur All the mips progressively
+
+    var inputRenderTarget = this.renderTargetBright;
+    for (let i = 0; i < 6; i++) {
+      this.fsQuad.material = this.separableBlurMaterials[ i ];
+
+      this.separableBlurMaterials[ i ].uniforms[ 'colorTexture' ].value = inputRenderTarget.texture;
+      this.separableBlurMaterials[ i ].uniforms[ 'direction' ].value = new THREE.Vector2(1.0, 0.0);
+      renderer.setRenderTarget(this.renderTargetsHorizontal[ i ]);
+      renderer.clear();
+      this.fsQuad.render(renderer);
+
+      this.separableBlurMaterials[ i ].uniforms[ 'colorTexture' ].value = this.renderTargetsHorizontal[ i ].texture;
+      this.separableBlurMaterials[ i ].uniforms[ 'direction' ].value = new THREE.Vector2(0.0, 1.0);
+      renderer.setRenderTarget(this.renderTargetsVertical[ i ]);
+      renderer.clear();
+      this.fsQuad.render(renderer);
+
+      inputRenderTarget = this.renderTargetsVertical[ i ];
+    }
+
+    // Composite All the mips
+
+    this.fsQuad.material = this.compositeMaterial;
+    renderer.setRenderTarget(this.renderTargetsHorizontal[ 0 ]);
+    renderer.clear();
+    this.fsQuad.render(renderer);
+
+    // Blend it additively over the input texture
+
+    this.fsQuad.material = this.materialCopy;
+    this.copyUniforms[ 'tDiffuse' ].value = this.renderTargetsHorizontal[ 0 ].texture;
+
+    if (maskActive)
+      renderer.context.enable(renderer.context.STENCIL_TEST);
+
+    if (this.renderToScreen) {
+      renderer.setRenderTarget(null);
+      this.fsQuad.render(renderer);
+    } else {
+      renderer.setRenderTarget(readBuffer);
+      this.fsQuad.render(renderer);
+    }
+
+    // Restore renderer settings
+
+    renderer.setClearColor(this.oldClearColor, this.oldClearAlpha);
+    renderer.autoClear = oldAutoClear;
+  }
+};

--- a/resources/web/wwi/passes/bloom.js
+++ b/resources/web/wwi/passes/bloom.js
@@ -174,6 +174,19 @@ THREE.Bloom = class Bloom extends THREE.Pass {
     renderer.clear();
     this.fsQuad.render(renderer);
 
+    /*
+    // Code to debug bloom passes.
+    if (this.debugMaterial) {
+      var width = renderer.getSize().x / 2;
+      var height = renderer.getSize().y / 2;
+      var texture = new THREE.DataTexture(undefined, width, height, THREE.RGBFormat);
+      texture.needsUpdate = true;
+      renderer.copyFramebufferToTexture(new THREE.Vector2(), texture);
+      this.debugMaterial.map = texture;
+      this.debugMaterial.needsUpdate = true;
+    }
+    */
+
     // 2. Blur All the mips progressively
 
     var inputRenderTarget = this.renderTargetBright;

--- a/resources/web/wwi/passes/bloom.js
+++ b/resources/web/wwi/passes/bloom.js
@@ -11,7 +11,7 @@ THREE.Bloom = class Bloom extends THREE.Pass {
     this.clearColor = new THREE.Color(0, 0, 0);
 
     // render targets
-    var pars = { minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter, format: THREE.RGBAFormat };
+    var pars = { minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter, format: THREE.RGBAFormat, type: THREE.FloatType };
     this.renderTargetsHorizontal = [];
     this.renderTargetsVertical = [];
     var resx = Math.round(this.resolution.x / 2);

--- a/resources/web/wwi/shaders/blend_bloom.js
+++ b/resources/web/wwi/shaders/blend_bloom.js
@@ -29,7 +29,7 @@ THREE.blendBloomShader = {
     'uniform sampler2D blurTexture4;',
     'uniform sampler2D blurTexture5;',
     'uniform sampler2D blurTexture6;',
-    '',
+
     'void main() {',
     '  gl_FragColor = vec4(0.1 * vec3(',
     '    0.1 * texture2D(blurTexture1, vUv).rgb + ',

--- a/resources/web/wwi/shaders/blend_bloom.js
+++ b/resources/web/wwi/shaders/blend_bloom.js
@@ -1,0 +1,44 @@
+/* global THREE */
+
+// equivalent of: WEBOTS_HOME/resources/wren/shaders/blend_bloom.frag
+
+THREE.blendBloomShader = {
+
+  uniforms: {
+    'blurTexture1': { value: null },
+    'blurTexture2': { value: null },
+    'blurTexture3': { value: null },
+    'blurTexture4': { value: null },
+    'blurTexture5': { value: null },
+    'blurTexture6': { value: null }
+  },
+
+  vertexShader: [
+    'varying vec2 vUv;',
+    'void main() {',
+    '  vUv = uv;',
+    '  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);',
+    '}'
+  ].join('\n'),
+
+  fragmentShader: [
+    'varying vec2 vUv;',
+    'uniform sampler2D blurTexture1;',
+    'uniform sampler2D blurTexture2;',
+    'uniform sampler2D blurTexture3;',
+    'uniform sampler2D blurTexture4;',
+    'uniform sampler2D blurTexture5;',
+    'uniform sampler2D blurTexture6;',
+    '',
+    'void main() {',
+    '  gl_FragColor = vec4(0.1 * vec3(',
+    '    0.1 * texture2D(blurTexture1, vUv).rgb + ',
+    '    0.2 * texture2D(blurTexture2, vUv).rgb + ',
+    '    0.4 * texture2D(blurTexture3, vUv).rgb + ',
+    '    0.8 * texture2D(blurTexture4, vUv).rgb + ',
+    '    1.6 * texture2D(blurTexture5, vUv).rgb + ',
+    '    3.2 * texture2D(blurTexture6, vUv).rgb',
+    '  ), 1.0);',
+    '}'
+  ].join('\n')
+};

--- a/resources/web/wwi/shaders/bright_pass.js
+++ b/resources/web/wwi/shaders/bright_pass.js
@@ -1,0 +1,61 @@
+/* global THREE */
+
+// equivalent of: WEBOTS_HOME/resources/wren/shaders/bright_pass.frag
+
+THREE.brightPassShader = {
+
+  uniforms: {
+    'tDiffuse': { value: null },
+    'threshold': { value: 21.0 },
+    'textureSize': { value: new THREE.Vector2(800, 600)}
+  },
+
+  vertexShader: [
+    'varying vec2 texUv;',
+
+    'void main() {',
+    '  texUv = uv;',
+    '  gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );',
+    '}'
+  ].join('\n'),
+
+  fragmentShader: [
+    'uniform sampler2D tDiffuse;',
+    'uniform float threshold;',
+    'uniform vec2 textureSize;',
+
+    'varying vec2 texUv;',
+
+    'float luma(vec3 color) {',
+    '  return dot(color, vec3(0.299, 0.587, 0.114));',
+    '}',
+
+    'bool isnan(float val) {',
+    '  return (val <= 0.0 || 0.0 <= val) ? false : true;',
+    '}',
+
+    'void main() {',
+    '  vec4 color = texture2D( tDiffuse, texUv );',
+    '  float totalLuma = luma( color.xyz );',
+
+    '  totalLuma += luma(texture2D(tDiffuse, texUv + vec2(0, 1) / textureSize).rgb);',
+    '  totalLuma += luma(texture2D(tDiffuse, texUv + vec2(0, -1) / textureSize).rgb);',
+    '  totalLuma += luma(texture2D(tDiffuse, texUv + vec2(-1, 0) / textureSize).rgb);',
+    '  totalLuma += luma(texture2D(tDiffuse, texUv + vec2(1, 0) / textureSize).rgb);',
+    '  totalLuma += luma(texture2D(tDiffuse, texUv + vec2(1, 1) / textureSize).rgb);',
+    '  totalLuma += luma(texture2D(tDiffuse, texUv + vec2(1, -1) / textureSize).rgb);',
+    '  totalLuma += luma(texture2D(tDiffuse, texUv + vec2(-1, 1) / textureSize).rgb);',
+    '  totalLuma += luma(texture2D(tDiffuse, texUv + vec2(-1, -1) / textureSize).rgb);',
+    '  totalLuma /= 9.0;',
+
+    ' if (totalLuma < 1.0)', // TODO: Switch hard-coded "1.0" threshold to the `threshold` uniform.
+    '   gl_FragColor = vec4(vec3(0.0), 1.0);',
+    ' else {',
+    '   gl_FragColor.r = min(color.r, 4000.0);',
+    '   gl_FragColor.g = min(color.g, 4000.0);',
+    '   gl_FragColor.b = min(color.b, 4000.0);',
+    '   gl_FragColor.a = 1.0;',
+    ' }',
+    '}'
+  ].join('\n')
+};

--- a/resources/web/wwi/shaders/bright_pass.js
+++ b/resources/web/wwi/shaders/bright_pass.js
@@ -48,7 +48,7 @@ THREE.brightPassShader = {
     '  totalLuma += luma(texture2D(tDiffuse, texUv + vec2(-1, -1) / textureSize).rgb);',
     '  totalLuma /= 9.0;',
 
-    ' if (totalLuma < 1.0)', // TODO: Switch hard-coded "1.0" threshold to the `threshold` uniform.
+    ' if (totalLuma < threshold)',
     '   gl_FragColor = vec4(vec3(0.0), 1.0);',
     ' else {',
     '   gl_FragColor.r = min(color.r, 4000.0);',

--- a/resources/web/wwi/shaders/gaussian_blur_13_tap.js
+++ b/resources/web/wwi/shaders/gaussian_blur_13_tap.js
@@ -22,7 +22,6 @@ THREE.gaussianBlur13Tap = {
     '}'
   ].join('\n'),
   fragmentShader: [
-    '#include <common>',
     'varying vec2 vUv;',
     'uniform sampler2D colorTexture;',
     'uniform vec2 texSize;',

--- a/resources/web/wwi/shaders/gaussian_blur_13_tap.js
+++ b/resources/web/wwi/shaders/gaussian_blur_13_tap.js
@@ -1,0 +1,52 @@
+/* global THREE */
+
+// equivalent of: WEBOTS_HOME/resources/wren/shaders/gaussian_blur_13_tap.frag
+
+THREE.gaussianBlur13Tap = {
+  defines: {
+    'KERNEL_RADIUS': 1,
+    'SIGMA': 1
+  },
+
+  uniforms: {
+    'colorTexture': { value: null },
+    'texSize': { value: new THREE.Vector2(0.5, 0.5) },
+    'direction': { value: new THREE.Vector2(0.5, 0.5) }
+  },
+
+  vertexShader: [
+    'varying vec2 vUv;',
+    'void main() {',
+    '  vUv = uv;',
+    '  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);',
+    '}'
+  ].join('\n'),
+  fragmentShader: [
+    '#include <common>',
+    'varying vec2 vUv;',
+    'uniform sampler2D colorTexture;',
+    'uniform vec2 texSize;',
+    'uniform vec2 direction;',
+
+    'float gaussianPdf(in float x, in float sigma) {',
+    '  return 0.39894 * exp(-0.5 * x * x/(sigma * sigma))/sigma;',
+    '}',
+
+    'void main() {',
+    '  vec2 invSize = 1.0 / texSize;',
+    '  float fSigma = float(SIGMA);',
+    '  float weightSum = gaussianPdf(0.0, fSigma);',
+    '  vec3 diffuseSum = texture2D(colorTexture, vUv).rgb * weightSum;',
+    '  for(int i = 1; i < KERNEL_RADIUS; i ++) {',
+    '    float x = float(i);',
+    '    float w = gaussianPdf(x, fSigma);',
+    '    vec2 uvOffset = direction * invSize * x;',
+    '    vec3 sample1 = texture2D(colorTexture, vUv + uvOffset).rgb;',
+    '    vec3 sample2 = texture2D(colorTexture, vUv - uvOffset).rgb;',
+    '    diffuseSum += (sample1 + sample2) * w;',
+    '    weightSum += 2.0 * w;',
+    '  }',
+    '  gl_FragColor = vec4(diffuseSum/weightSum, 1.0);',
+    '}'
+  ].join('\n')
+};

--- a/resources/web/wwi/x3d.js
+++ b/resources/web/wwi/x3d.js
@@ -1001,6 +1001,7 @@ THREE.X3DLoader = class X3DLoader {
     this.scene.viewpoint.camera.userData.followedId = getNodeAttribute(viewpoint, 'followedId', null);
     this.scene.viewpoint.camera.userData.followSmoothness = getNodeAttribute(viewpoint, 'followSmoothness', null);
     this.scene.viewpoint.camera.userData.exposure = parseFloat(getNodeAttribute(viewpoint, 'exposure', '1.0'));
+    this.scene.viewpoint.camera.userData.bloomThreshold = parseFloat(getNodeAttribute(viewpoint, 'bloomThreshold', '21.0'));
     return undefined;
   }
 

--- a/resources/web/wwi/x3d_scene.js
+++ b/resources/web/wwi/x3d_scene.js
@@ -50,6 +50,9 @@ class X3dScene { // eslint-disable-line no-unused-vars
     this.composer = new THREE.EffectComposer(this.renderer);
     let renderPass = new THREE.RenderPass(this.scene, this.viewpoint.camera);
     this.composer.addPass(renderPass);
+    var bloomPass = new THREE.Bloom(new THREE.Vector2(window.innerWidth, window.innerHeight));
+    bloomPass.threshold = 21.0;
+    this.composer.addPass(bloomPass);
     this.hdrResolvePass = new THREE.ShaderPass(THREE.HDRResolveShader);
     this.composer.addPass(this.hdrResolvePass);
     var fxaaPass = new THREE.ShaderPass(THREE.FXAAShader);

--- a/resources/web/wwi/x3d_scene.js
+++ b/resources/web/wwi/x3d_scene.js
@@ -51,7 +51,7 @@ class X3dScene { // eslint-disable-line no-unused-vars
     let renderPass = new THREE.RenderPass(this.scene, this.viewpoint.camera);
     this.composer.addPass(renderPass);
     var bloomPass = new THREE.Bloom(new THREE.Vector2(window.innerWidth, window.innerHeight));
-    bloomPass.threshold = 21.0;
+    bloomPass.threshold = 1.0; // TODO: link with Viewpoint.bloomThreshold
     this.composer.addPass(bloomPass);
     this.hdrResolvePass = new THREE.ShaderPass(THREE.HDRResolveShader);
     this.composer.addPass(this.hdrResolvePass);

--- a/resources/web/wwi/x3d_scene.js
+++ b/resources/web/wwi/x3d_scene.js
@@ -66,8 +66,10 @@ class X3dScene { // eslint-disable-line no-unused-vars
   }
 
   render() {
+    // Apply pass uniforms.
     this.hdrResolvePass.material.uniforms['exposure'].value = 2.0 * this.viewpoint.camera.userData.exposure; // Factor empirically found to match the Webots rendering.
     this.bloomPass.threshold = this.viewpoint.camera.userData.bloomThreshold;
+    this.bloomPass.enabled = this.bloomPass.threshold >= 0;
 
     if (typeof this.preRender === 'function')
       this.preRender(this.scene, this.viewpoint.camera);

--- a/resources/web/wwi/x3d_scene.js
+++ b/resources/web/wwi/x3d_scene.js
@@ -51,7 +51,6 @@ class X3dScene { // eslint-disable-line no-unused-vars
     let renderPass = new THREE.RenderPass(this.scene, this.viewpoint.camera);
     this.composer.addPass(renderPass);
     this.bloomPass = new THREE.Bloom(new THREE.Vector2(window.innerWidth, window.innerHeight));
-    this.bloomPass.threshold = 1.0; // TODO: link with Viewpoint.bloomThreshold
     this.composer.addPass(this.bloomPass);
     this.hdrResolvePass = new THREE.ShaderPass(THREE.HDRResolveShader);
     this.composer.addPass(this.hdrResolvePass);
@@ -68,6 +67,7 @@ class X3dScene { // eslint-disable-line no-unused-vars
 
   render() {
     this.hdrResolvePass.material.uniforms['exposure'].value = 2.0 * this.viewpoint.camera.userData.exposure; // Factor empirically found to match the Webots rendering.
+    this.bloomPass.threshold = this.viewpoint.camera.userData.bloomThreshold;
 
     if (typeof this.preRender === 'function')
       this.preRender(this.scene, this.viewpoint.camera);

--- a/resources/web/wwi/x3d_scene.js
+++ b/resources/web/wwi/x3d_scene.js
@@ -50,9 +50,9 @@ class X3dScene { // eslint-disable-line no-unused-vars
     this.composer = new THREE.EffectComposer(this.renderer);
     let renderPass = new THREE.RenderPass(this.scene, this.viewpoint.camera);
     this.composer.addPass(renderPass);
-    var bloomPass = new THREE.Bloom(new THREE.Vector2(window.innerWidth, window.innerHeight));
-    bloomPass.threshold = 1.0; // TODO: link with Viewpoint.bloomThreshold
-    this.composer.addPass(bloomPass);
+    this.bloomPass = new THREE.Bloom(new THREE.Vector2(window.innerWidth, window.innerHeight));
+    this.bloomPass.threshold = 1.0; // TODO: link with Viewpoint.bloomThreshold
+    this.composer.addPass(this.bloomPass);
     this.hdrResolvePass = new THREE.ShaderPass(THREE.HDRResolveShader);
     this.composer.addPass(this.hdrResolvePass);
     var fxaaPass = new THREE.ShaderPass(THREE.FXAAShader);
@@ -104,6 +104,16 @@ class X3dScene { // eslint-disable-line no-unused-vars
     this.useNodeCache = {};
     this.root = undefined;
     this.scene.background = undefined;
+
+    /*
+    // Code to debug bloom passes.
+    var geometry = new THREE.PlaneGeometry(5, 5);
+    var material = new THREE.MeshStandardMaterial({color: 0xffffff, side: THREE.DoubleSide});
+    this.bloomPass.debugMaterial = material;
+    var plane = new THREE.Mesh(geometry, material);
+    this.scene.add(plane);
+    */
+
     this.onSceneUpdate();
     this.render();
   }

--- a/src/webots/nodes/WbViewpoint.cpp
+++ b/src/webots/nodes/WbViewpoint.cpp
@@ -1494,6 +1494,7 @@ void WbViewpoint::exportNodeFields(WbVrmlWriter &writer) const {
 
   if (writer.isX3d()) {
     writer << " exposure=\'" << mExposure->value() << "\'";
+    writer << " bloomThreshold=\'" << mBloomThreshold->value() << "\'";
     writer << " zNear=\'" << mNear->value() << "\'";
     writer << " followSmoothness=\'" << mFollowSmoothness->value() << "\'";
     if (mFollowedSolid)

--- a/src/webots/nodes/WbViewpoint.cpp
+++ b/src/webots/nodes/WbViewpoint.cpp
@@ -356,6 +356,7 @@ void WbViewpoint::updateAmbientOcclusionRadius() {
 
 void WbViewpoint::updateBloomThreshold() {
   WbFieldChecker::resetDoubleIfNegativeAndNotDisabled(this, mBloomThreshold, 21.0, -1.0);
+  updatePostProcessingEffects();
 }
 
 WbLensFlare *WbViewpoint::lensFlare() const {

--- a/src/webots/nodes/WbViewpoint.cpp
+++ b/src/webots/nodes/WbViewpoint.cpp
@@ -1144,6 +1144,8 @@ void WbViewpoint::updatePostProcessingEffects() {
       mWrenBloom->detachFromViewport();
     else
       mWrenBloom->setup(mWrenViewport);
+
+    mWrenBloom->setThreshold(mBloomThreshold->value());
   }
 
   emit refreshRequired();


### PR DESCRIPTION
Aim: Add the bloom post processing in webots.min.js

Apply and improve #408, now possible thanks to #528

- [x] Replicate the bloom rendering pass in `webots.min.js`
- [x] Map the `Viewpoint.bloomThreshold` with `webots.min.js`
- [x] Adjust parameters to reduce the rendering gap.
- [x] Log

Around this PR:

- [x] Fix Viewpoint.bloomThreshold runtime update which was not applied.
- [x] Add a `debug` mode to the `webots.min.js` Makefile in order to build a `webots.debug.js` file which is not minified and obfuscated (very helpful to debug).