### PR TITLE
Hotfix rounding issues

### DIFF
--- a/src/webots/maths/WbPrecision.cpp
+++ b/src/webots/maths/WbPrecision.cpp
@@ -53,23 +53,6 @@ QString WbPrecision::doubleToString(double value, Level level) {
   }
 }
 
-const double WbPrecision::epsilon(Level level) {
-  switch (level) {
-    case DOUBLE_MAX:
-      return std::numeric_limits<double>::epsilon();
-    case FLOAT_MAX:
-      return std::numeric_limits<float>::epsilon();
-    case GUI_MEDIUM:
-      return 1e-6;
-    case GUI_LOW:
-      return 1e-3;
-    default:
-      assert(false);
-      return 0;
-  }
-}
-
 double WbPrecision::roundValue(double value, Level level) {
-  const double epsilon = WbPrecision::epsilon(level);
-  return round(value / epsilon) * epsilon;
+  return doubleToString(value, level).toDouble();
 }

--- a/src/webots/maths/WbPrecision.hpp
+++ b/src/webots/maths/WbPrecision.hpp
@@ -38,7 +38,6 @@ namespace WbPrecision {
   //     - the result is the shortest possible string.
   QString doubleToString(double value, Level level);
 
-  const double epsilon(Level level);
   double roundValue(double value, Level level);
 
 };  // namespace WbPrecision

--- a/src/webots/scene_tree/WbDoubleEditor.cpp
+++ b/src/webots/scene_tree/WbDoubleEditor.cpp
@@ -70,7 +70,7 @@ void WbDoubleEditor::resetFocus() {
 
 void WbDoubleEditor::applyIfNeeded() {
   if (field() && ((field()->hasRestrictedValues() && mDouble != mComboBox->currentText().toDouble()) ||
-                  (!field()->hasRestrictedValues() && mDouble != mSpinBox->text().toDouble())))
+                  (!field()->hasRestrictedValues() && mDouble != mSpinBox->value())))
     apply();
 }
 
@@ -80,7 +80,8 @@ void WbDoubleEditor::takeKeyboardFocus() {
 }
 
 void WbDoubleEditor::apply() {
-  mDouble = field()->hasRestrictedValues() ? mComboBox->currentText().toDouble() : mSpinBox->text().toDouble();
+  mDouble = field()->hasRestrictedValues() ? mComboBox->currentText().toDouble() :
+                                             WbPrecision::roundValue(mSpinBox->value(), WbPrecision::GUI_MEDIUM);
   if (singleValue()) {
     WbSFDouble *const sfDouble = static_cast<WbSFDouble *>(singleValue());
     if (sfDouble->value() == mDouble)

--- a/src/webots/scene_tree/WbVector2Editor.cpp
+++ b/src/webots/scene_tree/WbVector2Editor.cpp
@@ -86,9 +86,9 @@ void WbVector2Editor::takeKeyboardFocus() {
 }
 
 void WbVector2Editor::applyIfNeeded() {
-  if (field() && ((field()->hasRestrictedValues() && mVector2 != WbVector2(mComboBox->currentText())) ||
-                  (!field()->hasRestrictedValues() &&
-                   (mVector2.x() != mSpinBoxes[0]->text().toDouble() || mVector2.y() != mSpinBoxes[1]->text().toDouble()))))
+  if (field() &&
+      ((field()->hasRestrictedValues() && mVector2 != WbVector2(mComboBox->currentText())) ||
+       (!field()->hasRestrictedValues() && (mVector2.x() != mSpinBoxes[0]->value() || mVector2.y() != mSpinBoxes[1]->value()))))
     apply();
 }
 
@@ -96,7 +96,8 @@ void WbVector2Editor::apply() {
   if (field()->hasRestrictedValues())
     mVector2 = WbVector2(mComboBox->currentText());
   else
-    mVector2.setXy(mSpinBoxes[0]->text().toDouble(), mSpinBoxes[1]->text().toDouble());
+    mVector2.setXy(WbPrecision::roundValue(mSpinBoxes[0]->value(), WbPrecision::GUI_MEDIUM),
+                   WbPrecision::roundValue(mSpinBoxes[1]->value(), WbPrecision::GUI_MEDIUM));
 
   if (singleValue()) {
     WbSFVector2 *const sfVector2 = static_cast<WbSFVector2 *>(singleValue());

--- a/src/webots/scene_tree/WbVector3Editor.cpp
+++ b/src/webots/scene_tree/WbVector3Editor.cpp
@@ -95,10 +95,10 @@ void WbVector3Editor::resetFocus() {
 }
 
 void WbVector3Editor::applyIfNeeded() {
-  if (field() && ((field()->hasRestrictedValues() && mVector3 != WbVector3(mComboBox->currentText())) ||
-                  (!field()->hasRestrictedValues() &&
-                   (mVector3.x() != mSpinBoxes[0]->text().toDouble() || mVector3.y() != mSpinBoxes[1]->text().toDouble() ||
-                    mVector3.z() != mSpinBoxes[2]->text().toDouble()))))
+  if (field() &&
+      ((field()->hasRestrictedValues() && mVector3 != WbVector3(mComboBox->currentText())) ||
+       (!field()->hasRestrictedValues() && (mVector3.x() != mSpinBoxes[0]->value() || mVector3.y() != mSpinBoxes[1]->value() ||
+                                            mVector3.z() != mSpinBoxes[2]->value()))))
     apply();
 }
 
@@ -106,7 +106,9 @@ void WbVector3Editor::apply() {
   if (field()->hasRestrictedValues())
     mVector3 = WbVector3(mComboBox->currentText());
   else
-    mVector3.setXyz(mSpinBoxes[0]->text().toDouble(), mSpinBoxes[1]->text().toDouble(), mSpinBoxes[2]->text().toDouble());
+    mVector3.setXyz(WbPrecision::roundValue(mSpinBoxes[0]->value(), WbPrecision::GUI_MEDIUM),
+                    WbPrecision::roundValue(mSpinBoxes[1]->value(), WbPrecision::GUI_MEDIUM),
+                    WbPrecision::roundValue(mSpinBoxes[2]->value(), WbPrecision::GUI_MEDIUM));
 
   if (singleValue()) {
     WbSFVector3 *const sfVector3 = static_cast<WbSFVector3 *>(singleValue());


### PR DESCRIPTION
Fix #582: improve fix in #627 by changing the rounding method so that it uses the `WbPrecision::doubleToString` rounded value.

Using the string value to round reduces differences when saving the value to file and make it more robust to the intrinsic floating noise.
Note that for almost all the values the two rounding methods are equivalent.

This is the same principle it was used in #627 where the value was extracted from the spin box text, but now it has a higher precision that fixes the reset to default issue.