### PR TITLE
Skip AppVeyor test on merge

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 skip_commits:
-  - message: /^Merge pull request /
+  - message: /Merge pull request/
 
 clone_depth: 1
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,9 +4,6 @@ branches:
     - revision
     - master
 
-skip_commits:
-  - message: /Merge pull request/
-
 clone_depth: 1
 
 install:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,3 +1,9 @@
+branches:
+  except:
+    - develop
+    - revision
+    - master
+
 skip_commits:
   - message: /Merge pull request/
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 skip_commits:
-  - message: /^Merge pull request #/
+  - message: /^Merge pull request /
 
 clone_depth: 1
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,3 +1,6 @@
+skip_commits:
+  - message: /^Merge pull request #/
+
 clone_depth: 1
 
 install:


### PR DESCRIPTION
In this PR, we want to avoid launching useless AppVeyor source tests each time a branch is merged in master, revision or develop.