### PR TITLE
Fix Texture Picking

### DIFF
--- a/docs/reference/change-log-r2019.md
+++ b/docs/reference/change-log-r2019.md
@@ -5,6 +5,7 @@ Released on XXX YYth, 2019.
 
   - Bug fixes
     - Fixed ros controller not publishing the `/connector/presence` topic.
+    - Fixed crash when using an `infra-red` [DistanceSensors](distancesensor.md) dist pointing to a texture without repetition.
 
 ## [Webots R2019b](../blog/Webots-2019-b-release.md)
 Released on June 25th, 2019.

--- a/docs/reference/change-log-r2019.md
+++ b/docs/reference/change-log-r2019.md
@@ -5,7 +5,7 @@ Released on XXX YYth, 2019.
 
   - Bug fixes
     - Fixed ros controller not publishing the `/connector/presence` topic.
-    - Fixed crash when using an `infra-red` [DistanceSensors](distancesensor.md) dist pointing to a texture without repetition.
+    - Fixed crash when using an `infra-red` [DistanceSensors](distancesensor.md) pointing to a texture without repetition.
 
 ## [Webots R2019b](../blog/Webots-2019-b-release.md)
 Released on June 25th, 2019.

--- a/src/webots/nodes/WbImageTexture.cpp
+++ b/src/webots/nodes/WbImageTexture.cpp
@@ -359,7 +359,7 @@ void WbImageTexture::pickColor(WbRgb &pickedColor, const WbVector2 &uv) const {
   } else
     v = qBound(0.0, v, 1.0);
 
-  int index = 4 * ((int)(v * h) * w + (int)(u * w));
+  int index = 4 * ((int)(v * (h - 1)) * w + (int)(u * (w - 1)));
   pickedColor.setByteValue((int)data[index + 2], (int)data[index + 1], (int)data[index]);
 
   // debug


### PR DESCRIPTION
The wrong pixel was taken, which was in some cases even causing crashes (e.g. is uv = (1.0, 1.0)).