### PR TITLE
Speed-up Inno Setup compression

### DIFF
--- a/src/packaging/webots_distro.c
+++ b/src/packaging/webots_distro.c
@@ -224,6 +224,9 @@ static void copy_file(const char *file) {
       fprintf(fd, "Source: \"%s\"; DestDir: \"{app}\\%s\"", file2, dest2);
       if (file2[i + 1] == '.')
         fprintf(fd, "; Attribs: hidden");
+      if ((file2[l - 4] == '.' && file2[l - 3] == 'j' && file2[l - 2] == 'p' && file2[l - 1] == 'g') ||
+          (file2[l - 4] == '.' && file2[l - 3] == 'p' && file2[l - 2] == 'n' && file2[l - 1] == 'g'))
+        fprintf(fd, "; Flags: nocompression");
       fprintf(fd, "\n");
       break;
 #ifndef _WIN32
@@ -471,6 +474,7 @@ static void create_file(const char *name, int m) {
               "AppPublisher=Cyberbotics, Ltd.\n"
               "AppPublisherURL=https://www.cyberbotics.com\n"
               "ChangesEnvironment=yes\n"  // tells Windows Explorer to reload environment variables (e.g., WEBOTS_HOME)
+              "Compression=lzma2/fast\n"
               "DefaultDirName={autopf}\\%s\n"
               "DefaultGroupName=Cyberbotics\n"
               "UninstallDisplayIcon={app}\\msys64\\mingw64\\bin\\webots.exe\n"


### PR DESCRIPTION
This should fix #707.

Changing the compression ratio from "max" to "fast" and avoiding to compress `jpg` and `png` files (which are already compressed) allow us to lower the Inno Setup compilation time from 10:13 minutes down to 3:13 minutes on my computer. However, the resulting `webots_setup.exe` is 7% bigger (1,523 MB instead of 1,417 MB). On the appveyor VM, the Inno Setup compilation takes about 15 minutes, so the gain should be even better.

I believe this is a good compromise.