### PR TITLE
Add webots.debug.js to gitignore

### DIFF
--- a/resources/web/wwi/.gitignore
+++ b/resources/web/wwi/.gitignore
@@ -3,5 +3,6 @@
 /node_modules
 /package-lock.json
 /webots.min.js
+/webots.debug.js
 /adapter.js
 janus.nojquery.js


### PR DESCRIPTION
This file was missing in the gitignore.