### PR TITLE
Fix External Controller

### DIFF
--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -14,6 +14,7 @@ Released on XXX YYth, 2019.
   - Bug fixes
     - Fixed ros controller not publishing the `/connector/presence` topic.
     - Fixed crash when using an `infra-red` [DistanceSensors](distancesensor.md) pointing to a texture without repetition.
+    - Fixed external controllers, now when a controller exits, the simulation keeps running and it is possible to re-start another external controller.
 
 ## [Webots R2019b](../blog/Webots-2019-b-release.md)
 Released on June 25th, 2019.

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -112,6 +112,7 @@ WbController::WbController(WbRobot *robot) :
 
   mProcess = new QProcess();
 
+  connect(mRobot, &WbRobot::controllerExited, this, &WbController::handleControllerExit);
   connect(mProcess, &QProcess::readyReadStandardOutput, this, &WbController::readStdout);
   connect(mProcess, &QProcess::readyReadStandardError, this, &WbController::readStderr);
   connect(mProcess, SIGNAL(finished(int, QProcess::ExitStatus)), this, SLOT(processFinished(int, QProcess::ExitStatus)));
@@ -846,6 +847,13 @@ const QString &WbController::name() const {
 
 const QString &WbController::args() const {
   return mRobot->controllerArgs();
+}
+
+void WbController::handleControllerExit() {
+  if (mRobot->controllerName() == "<extern>") {
+    processFinished(0, QProcess::NormalExit);
+    mRobot->setControllerStarted(false);
+  }
 }
 
 void WbController::writeUserInputEventAnswer() {

--- a/src/webots/control/WbController.hpp
+++ b/src/webots/control/WbController.hpp
@@ -69,6 +69,7 @@ public slots:
   void readRequest();
   void appendMessageToConsole(const QString &message, bool useStdout);
   void writeUserInputEventAnswer();
+  void handleControllerExit();
 
 private:
   WbRobot *mRobot;

--- a/src/webots/nodes/WbRobot.cpp
+++ b/src/webots/nodes/WbRobot.cpp
@@ -880,11 +880,7 @@ void WbRobot::handleMessage(QDataStream &stream) {
         mJoystickInterface->setForceAxis(axis);
     }
     case C_ROBOT_CLIENT_EXIT_NOTIFY:
-      /*
-      C_Controller::displayControllerProcesses();
-      A_Application::addRobotConsolePrint(name->getValue(), _("controller has terminated.\n"), 1);
-      A_Application::setControllerRequest(this, NULL);
-      */
+      emit controllerExited();
       return;
     case C_ROBOT_REMOTE_ON:
       emit toggleRemoteMode(true);

--- a/src/webots/nodes/WbRobot.hpp
+++ b/src/webots/nodes/WbRobot.hpp
@@ -136,13 +136,13 @@ signals:
   void immediateMessageAdded();
   void controllerChanged();
   void controllerRestarted();
+  void controllerExited();
   void toggleRemoteMode(bool enable);
   void sendToJavascript(const QByteArray &);
   void appendMessageToConsole(const QString &message, bool useStdout);
   void userInputEventNeedUpdate();
   void keyboardChanged();
   void windowReady();
-  void controllerExited();
 
 protected:
   WbRobot(const QString &modelName, WbTokenizer *tokenizer);

--- a/src/webots/nodes/WbRobot.hpp
+++ b/src/webots/nodes/WbRobot.hpp
@@ -142,6 +142,7 @@ signals:
   void userInputEventNeedUpdate();
   void keyboardChanged();
   void windowReady();
+  void controllerExited();
 
 protected:
   WbRobot(const QString &modelName, WbTokenizer *tokenizer);


### PR DESCRIPTION
Once an external controller was exiting the `INFO: 'extern' controller exited successfully.` message was never displayed, it was not possible to re-launch the external controller and the simulation was blocked (because waiting for ht controller).