### PR TITLE
Improve Mavic 2 PRO lights

### DIFF
--- a/projects/robots/dji/mavic/worlds/mavic_2_pro.wbt
+++ b/projects/robots/dji/mavic/worlds/mavic_2_pro.wbt
@@ -15,17 +15,13 @@ Viewpoint {
   orientation 0.07050665473376751 -0.9955409361549733 -0.06266622757062013 4.81348648259329
   position 3.097238269380304 0.6132726075362769 0.5611797778962901
   near 0.2
-  exposure 4
   follow "Mavic 2 PRO"
   followSmoothness 0.2
 }
 TexturedBackground {
+  luminosity 3
 }
-DirectionalLight {
-  ambientIntensity 1
-  direction -0.6 -1 0.55
-  intensity 1.2
-  castShadows TRUE
+TexturedBackgroundLight {
 }
 Floor {
   size 400 400
@@ -145,7 +141,6 @@ Mavic2Pro {
       width 400
       height 240
       near 0.2
-      exposure 4
     }
   ]
 }


### PR DESCRIPTION
Use `Background.luminosity` instead of `Viewpoint.exposure` in order to not affect the Background colors.

| Before | After |
| --- | --- |
| ![mavic_2_pro](https://user-images.githubusercontent.com/866788/61713220-536eac00-ad58-11e9-8857-28a04ec924dc.png) | ![mavic_2_pro_new](https://user-images.githubusercontent.com/866788/61713219-52d61580-ad58-11e9-873b-6e1bbb9e42c7.png) |