### PR TITLE
Improve the vertical stabilization of the drone

### DIFF
--- a/projects/robots/dji/mavic/controllers/mavic2pro/mavic2pro.c
+++ b/projects/robots/dji/mavic/controllers/mavic2pro/mavic2pro.c
@@ -167,7 +167,7 @@ int main(int argc, char **argv) {
     const double pitch_input = k_pitch_p * CLAMP(pitch, -1.0, 1.0) - pitch_acceleration + pitch_disturbance;
     const double yaw_input = yaw_disturbance;
     const double clamped_difference_altitude = CLAMP(target_altitude - altitude + k_vertical_offset, -1.0, 1.0);
-    const double vertical_input =
+    const double vertical_input = k_vertical_p * pow(clamped_difference_altitude, 3.0);
       k_vertical_p * pow(clamped_difference_altitude, 3.0);
 
     // Actuate the motors taking into consideration all the computed inputs.

--- a/projects/robots/dji/mavic/controllers/mavic2pro/mavic2pro.c
+++ b/projects/robots/dji/mavic/controllers/mavic2pro/mavic2pro.c
@@ -168,7 +168,6 @@ int main(int argc, char **argv) {
     const double yaw_input = yaw_disturbance;
     const double clamped_difference_altitude = CLAMP(target_altitude - altitude + k_vertical_offset, -1.0, 1.0);
     const double vertical_input = k_vertical_p * pow(clamped_difference_altitude, 3.0);
-      k_vertical_p * pow(clamped_difference_altitude, 3.0);
 
     // Actuate the motors taking into consideration all the computed inputs.
     const double front_left_motor_input = k_vertical_thrust + vertical_input - roll_input - pitch_input + yaw_input;

--- a/projects/robots/dji/mavic/controllers/mavic2pro/mavic2pro.c
+++ b/projects/robots/dji/mavic/controllers/mavic2pro/mavic2pro.c
@@ -17,11 +17,13 @@
 /*
  * Description:  Simplistic drone control:
  * - Stabilize the robot using the embedded sensors.
- * - Use PID technique to stabilize the vertical input (the altitude differences are integrated.)
+ * - Use PID technique to stabilize the drone roll/pitch/yaw.
+ * - Use a cubic function applied on the vertical difference to stabilize the robot vertically.
  * - Stabilize the camera.
  * - Control the robot using the computer keyboard.
  */
 
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -95,14 +97,13 @@ int main(int argc, char **argv) {
 
   // Constants, empirically found.
   const double k_vertical_thrust = 68.5;  // with this thrust, the drone lifts.
-  const double k_vertical_p = 40.0;       // P constant of the vertical PID.
-  const double k_vertical_i = 0.005;      // I constant of the vertical PID.
+  const double k_vertical_offset = 0.6;   // Vertical offset where the robot stabilize actually.
+  const double k_vertical_p = 3.0;        // P constant of the vertical PID.
   const double k_roll_p = 50.0;           // P constant of the roll PID.
   const double k_pitch_p = 30.0;          // P constant of the pitch PID.
 
   // Variables.
   double target_altitude = 1.0;  // The target altitude. Can be changed by the user.
-  double sum_altitude = 0.0;     // Store the altitude difference sum.
 
   // Main loop
   while (wb_robot_step(timestep) != -1) {
@@ -150,28 +151,24 @@ int main(int argc, char **argv) {
           roll_disturbance = 1.0;
           break;
         case (WB_KEYBOARD_SHIFT + WB_KEYBOARD_UP):
-          target_altitude += 0.02;
+          target_altitude += 0.05;
           printf("target altitude: %f [m]\n", target_altitude);
           break;
         case (WB_KEYBOARD_SHIFT + WB_KEYBOARD_DOWN):
-          target_altitude -= 0.02;
+          target_altitude -= 0.05;
           printf("target altitude: %f [m]\n", target_altitude);
           break;
       }
       key = wb_keyboard_get_key();
     }
 
-    // Update `sum_altitude`.
-    const double difference_altitude = target_altitude - altitude;
-    if (SIGN(difference_altitude) != SIGN(sum_altitude))
-      sum_altitude = 0.0;  // Reset windup.
-    sum_altitude += difference_altitude;
-
     // Compute the roll, pitch, yaw and vertical inputs.
     const double roll_input = k_roll_p * CLAMP(roll, -1.0, 1.0) + roll_acceleration + roll_disturbance;
     const double pitch_input = k_pitch_p * CLAMP(pitch, -1.0, 1.0) - pitch_acceleration + pitch_disturbance;
     const double yaw_input = yaw_disturbance;
-    const double vertical_input = k_vertical_p * CLAMP(difference_altitude, -0.02, 0.02) + k_vertical_i * sum_altitude;
+    const double clamped_difference_altitude = CLAMP(target_altitude - altitude + k_vertical_offset, -1.0, 1.0);
+    const double vertical_input =
+      k_vertical_p * pow(clamped_difference_altitude, 3.0);
 
     // Actuate the motors taking into consideration all the computed inputs.
     const double front_left_motor_input = k_vertical_thrust + vertical_input - roll_input - pitch_input + yaw_input;

--- a/projects/robots/dji/mavic/controllers/mavic2pro/mavic2pro.c
+++ b/projects/robots/dji/mavic/controllers/mavic2pro/mavic2pro.c
@@ -97,7 +97,7 @@ int main(int argc, char **argv) {
 
   // Constants, empirically found.
   const double k_vertical_thrust = 68.5;  // with this thrust, the drone lifts.
-  const double k_vertical_offset = 0.6;   // Vertical offset where the robot stabilize actually.
+  const double k_vertical_offset = 0.6;   // Vertical offset where the robot actually targets to stabilize itself.
   const double k_vertical_p = 3.0;        // P constant of the vertical PID.
   const double k_roll_p = 50.0;           // P constant of the roll PID.
   const double k_pitch_p = 30.0;          // P constant of the pitch PID.


### PR DESCRIPTION
The oscillation around the vertical component was too big to create nice looking movies, and the PID control shows limitations for the component control. I slightly changed the stabilization algorithm to reduce this effect and found better and simpler solution using a cubic function to adjust the thrust around the target altitude:

https://www.desmos.com/calculator/gtkbezos9z

The drone is now stabilized after one oscillation. 