### PR TITLE
Fix the insertion of a PROTO containing a BallJoint

### DIFF
--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -12,6 +12,7 @@ Released on XXX YYth, 2019.
   - New Samples
     - Added new samples about the [Accelerometer](../guide/samples-devices.md#accelerometer-wbt) and [Brake](../guide/samples-devices.md#brake-wbt) devices.
   - Bug fixes
+    - Fixed the insertion of a PROTO containing a [BallJoint](balljoint.md).
     - Fixed ros controller not publishing the `/connector/presence` topic.
     - Fixed crash when using an `infra-red` [DistanceSensors](distancesensor.md) pointing to a texture without repetition.
     - Fixed external controllers, now when a controller exits, the simulation keeps running and it is possible to re-start another external controller.

--- a/src/webots/nodes/utils/WbNodeUtilities.cpp
+++ b/src/webots/nodes/utils/WbNodeUtilities.cpp
@@ -1369,7 +1369,7 @@ bool WbNodeUtilities::validateExistingChildNode(const WbField *const field, cons
   int result = NONE;
   if (fieldName == "device") {
     const WbJoint *joint = dynamic_cast<const WbJoint *>(node);
-    if (parentModelName.startsWith("Hinge")) {
+    if (parentModelName.startsWith("Hinge") || parentModelName == "BallJoint") {
       if (joint) {
         if (childModelName == "RotationalMotor")
           result = 1 + (static_cast<WbNode *>(joint->motor()) == childNode);
@@ -1401,6 +1401,16 @@ bool WbNodeUtilities::validateExistingChildNode(const WbField *const field, cons
       else if (childModelName == "Brake")
         result = 1 + (static_cast<WbNode *>(joint->brake2()) == childNode);
     }
+  } else if (fieldName == "device3") {
+      const WbBallJoint *joint = dynamic_cast<const WbBallJoint *>(node);
+      if (joint) {
+          if (childModelName == "RotationalMotor")
+              result = 1 + (static_cast<WbNode *>(joint->motor3()) == childNode);
+          else if (childModelName == "PositionSensor")
+              result = 1 + (static_cast<WbNode *>(joint->positionSensor3()) == childNode);
+          else if (childModelName == "Brake")
+              result = 1 + (static_cast<WbNode *>(joint->brake3()) == childNode);
+      }
   }
   if (result == ROBOT_ANCESTOR)  // valid if node has a robot ancestor
     return WbNodeUtilities::hasARobotAncestor(node);

--- a/src/webots/nodes/utils/WbNodeUtilities.cpp
+++ b/src/webots/nodes/utils/WbNodeUtilities.cpp
@@ -1402,15 +1402,15 @@ bool WbNodeUtilities::validateExistingChildNode(const WbField *const field, cons
         result = 1 + (static_cast<WbNode *>(joint->brake2()) == childNode);
     }
   } else if (fieldName == "device3") {
-      const WbBallJoint *joint = dynamic_cast<const WbBallJoint *>(node);
-      if (joint) {
-          if (childModelName == "RotationalMotor")
-              result = 1 + (static_cast<WbNode *>(joint->motor3()) == childNode);
-          else if (childModelName == "PositionSensor")
-              result = 1 + (static_cast<WbNode *>(joint->positionSensor3()) == childNode);
-          else if (childModelName == "Brake")
-              result = 1 + (static_cast<WbNode *>(joint->brake3()) == childNode);
-      }
+    const WbBallJoint *joint = dynamic_cast<const WbBallJoint *>(node);
+    if (joint) {
+      if (childModelName == "RotationalMotor")
+        result = 1 + (static_cast<WbNode *>(joint->motor3()) == childNode);
+      else if (childModelName == "PositionSensor")
+        result = 1 + (static_cast<WbNode *>(joint->positionSensor3()) == childNode);
+      else if (childModelName == "Brake")
+        result = 1 + (static_cast<WbNode *>(joint->brake3()) == childNode);
+    }
   }
   if (result == ROBOT_ANCESTOR)  // valid if node has a robot ancestor
     return WbNodeUtilities::hasARobotAncestor(node);


### PR DESCRIPTION
Following this discussion: https://stackoverflow.com/questions/57142908/why-cant-i-insert-a-rotationalmotor-node-in-device-field-of-balljoint-node-in?noredirect=1#comment100870939_57142908

The `BallJoint` case and the `BallJoint.device3` case were not validated correctly in `WbNodeUtilities::validateExistingChildNode()` causing the impossibility to insert a PROTO containing a BallJoint.