### PR TITLE
Fix roughness and metalness in `realistic_village.wbt`

### DIFF
--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -12,6 +12,7 @@ Released on XXX YYth, 2019.
   - New Samples
     - Added new samples about the [Accelerometer](../guide/samples-devices.md#accelerometer-wbt) and [Brake](../guide/samples-devices.md#brake-wbt) devices.
   - Bug fixes
+    - Fixed `realistic_village.wbt` materials.
     - Fixed the insertion of a PROTO containing a [BallJoint](balljoint.md).
     - Fixed ros controller not publishing the `/connector/presence` topic.
     - Fixed crash when using an `infra-red` [DistanceSensors](distancesensor.md) pointing to a texture without repetition.

--- a/projects/vehicles/worlds/village_realistic.wbt
+++ b/projects/vehicles/worlds/village_realistic.wbt
@@ -2161,10 +2161,6 @@ SimpleTree {
 BusStop {
   translation 418.69 0 -232.169
   rotation 0 -1 0 3.10841
-  appearance PBRAppearance {
-    roughness 1
-    metalness 0
-  }
 }
 Transform {
   translation 419.954 0.005 -235.522
@@ -2177,6 +2173,8 @@ Transform {
             "textures/bus_lines.png"
           ]
         }
+        roughness 1
+        metalness 0
       }
       geometry Plane {
         size 3.5 18
@@ -2188,10 +2186,6 @@ BusStop {
   translation 380.456 0 -331.021
   rotation 0 1 0 2.77419
   name "bus stop(1)"
-  appearance PBRAppearance {
-    roughness 1
-    metalness 0
-  }
 }
 BusSimple {
   translation 379.65333 0.55 -335.31941
@@ -2203,18 +2197,7 @@ Transform {
   translation 382.273 0.005 -334.983
   rotation 0 -1 0 5.07979
   children [
-    DEF BUS_SIGNS Shape {
-      appearance PBRAppearance {
-        baseColorMap ImageTexture {
-          url [
-            "textures/bus_lines.png"
-          ]
-        }
-      }
-      geometry Plane {
-        size 3.5 18
-      }
-    }
+    USE BUS_SIGNS
   ]
 }
 BusStop {
@@ -2222,27 +2205,12 @@ BusStop {
   rotation 0 -1 0 2.2
   name "bus stop(2)"
   bench FALSE
-  appearance PBRAppearance {
-    roughness 1
-    metalness 0
-  }
 }
 Transform {
   translation 537.645 0.005 -339.349
   rotation 0 1 0 2.45
   children [
-    DEF BUS_SIGNS Shape {
-      appearance PBRAppearance {
-        baseColorMap ImageTexture {
-          url [
-            "textures/bus_lines.png"
-          ]
-        }
-      }
-      geometry Plane {
-        size 3.5 18
-      }
-    }
+    USE BUS_SIGNS
   ]
 }
 BusStop {
@@ -2250,10 +2218,6 @@ BusStop {
   rotation 0 -1 0 1.81121
   name "bus stop(3)"
   bench FALSE
-  appearance PBRAppearance {
-    roughness 1
-    metalness 0
-  }
 }
 BusSimple {
   translation 650.062 0.55 -279.158
@@ -2265,126 +2229,55 @@ Transform {
   translation 650.534 0.005 -281.79
   rotation 0 1 0 2.92
   children [
-    DEF BUS_SIGNS Shape {
-      appearance PBRAppearance {
-        baseColorMap ImageTexture {
-          url [
-            "textures/bus_lines.png"
-          ]
-        }
-      }
-      geometry Plane {
-        size 3.5 18
-      }
-    }
+    USE BUS_SIGNS
   ]
 }
 BusStop {
   translation 603.325 0 -105.434
   rotation 0 -1 0 2.85841
   name "bus stop(4)"
-  appearance PBRAppearance {
-    roughness 1
-    metalness 0
-  }
 }
 Transform {
   translation 602.452 0.005 -108.757
   rotation 0 1 0 1.83159
   children [
-    DEF BUS_SIGNS Shape {
-      appearance PBRAppearance {
-        baseColorMap ImageTexture {
-          url [
-            "textures/bus_lines.png"
-          ]
-        }
-      }
-      geometry Plane {
-        size 3.5 18
-      }
-    }
+    USE BUS_SIGNS
   ]
 }
 BusStop {
   translation 530.632 0 -186.21
   rotation 0 -1 0 5.82478
   name "bus stop(5)"
-  appearance PBRAppearance {
-    roughness 1
-    metalness 0
-  }
 }
 Transform {
   translation 532.623 0.005 -183.693
   rotation 0 -1 0 1.13
   children [
-    DEF BUS_SIGNS Shape {
-      appearance PBRAppearance {
-        baseColorMap ImageTexture {
-          url [
-            "textures/bus_lines.png"
-          ]
-        }
-      }
-      geometry Plane {
-        size 3.5 18
-      }
-    }
+    USE BUS_SIGNS
   ]
 }
 BusStop {
   translation 568.159 0 -107.901
   rotation 7.13274e-08 -1 -2.86931e-08 6.02478
   name "bus stop(6)"
-  appearance PBRAppearance {
-    roughness 1
-    metalness 0
-  }
 }
 Transform {
   translation 570.124 0.005 -104.304
   rotation 0 -1 0 1.35
   children [
-    DEF BUS_SIGNS Shape {
-      appearance PBRAppearance {
-        baseColorMap ImageTexture {
-          url [
-            "textures/bus_lines.png"
-          ]
-        }
-      }
-      geometry Plane {
-        size 3.5 18
-      }
-    }
+    USE BUS_SIGNS
   ]
 }
 BusStop {
   translation 521.358 0 -170.793
   rotation 0 -1 0 2.73319
   name "bus stop(7)"
-  appearance PBRAppearance {
-    roughness 1
-    metalness 0
-  }
 }
 Transform {
   translation 521.419 0.005 -174.589
   rotation 0 1 0 1.9792
   children [
-    DEF BUS_SIGNS Shape {
-      appearance PBRAppearance {
-        baseColorMap ImageTexture {
-          url [
-            "textures/bus_lines.png"
-          ]
-        }
-      }
-      geometry Plane {
-        size 3.5 18
-      }
-    }
+    USE BUS_SIGNS
   ]
 }
 SimpleBuilding {
@@ -3539,10 +3432,8 @@ SimpleTree {
   radius 1
   subdivision 3
 }
-Fountain {
-  translation 555.921 0.005 -181.427
-  height 4
-  radius 3
+StoneFountain {
+  translation 557.248 0.005 -183.416
 }
 BungalowStyleHouse {
   translation 544.569 0.005 -170.582

--- a/projects/vehicles/worlds/village_realistic.wbt
+++ b/projects/vehicles/worlds/village_realistic.wbt
@@ -3843,15 +3843,7 @@ DEF RIVER Transform {
     Shape {
       appearance PBRAppearance {
         baseColor 0.17 0.45 0.7
-        baseColorMap ImageTexture {
-          url [
-            "textures/water.jpg"
-          ]
-        }
         metalness 0
-        textureTransform DEF SEA_TEXTURE_TRANSFORM TextureTransform {
-          scale 500 500
-        }
       }
       geometry Extrusion {
         crossSection [
@@ -3887,15 +3879,7 @@ DEF SMALL_LAKE Transform {
     DEF water Shape {
       appearance PBRAppearance {
         baseColor 0.17 0.45 0.7
-        baseColorMap ImageTexture {
-          url [
-            "textures/water.jpg"
-          ]
-        }
         metalness 0
-        textureTransform DEF SEA_TEXTURE_TRANSFORM TextureTransform {
-          scale 500 500
-        }
       }
       geometry IndexedFaceSet {
         coord Coordinate {
@@ -4073,15 +4057,7 @@ DEF BIG_LAKE Transform {
     DEF water Shape {
       appearance PBRAppearance {
         baseColor 0.17 0.45 0.7
-        baseColorMap ImageTexture {
-          url [
-            "textures/water.jpg"
-          ]
-        }
         metalness 0
-        textureTransform DEF SEA_TEXTURE_TRANSFORM TextureTransform {
-          scale 500 500
-        }
       }
       geometry IndexedFaceSet {
         coord Coordinate {

--- a/projects/vehicles/worlds/village_realistic.wbt
+++ b/projects/vehicles/worlds/village_realistic.wbt
@@ -141,7 +141,7 @@ Fence {
   height 0.4
   poleGap 0.35
   poleRadius 0.2
-  poleAppearance PaintedWood {
+  poleAppearance RoughPine {
   }
   path [
     4.4 0 0.7
@@ -166,7 +166,7 @@ DEF FLOWERS Solid {
       height 0.2
       poleGap 0.09
       poleRadius 0.05
-      poleAppearance PaintedWood {
+      poleAppearance RoughPine {
       }
       path [
         0 0 0
@@ -214,7 +214,7 @@ DEF FLOWERS Solid {
       height 0.2
       poleGap 0.09
       poleRadius 0.05
-      poleAppearance PaintedWood {
+      poleAppearance RoughPine {
       }
       path [
         0 0 0
@@ -745,7 +745,7 @@ DEF FLOWERS Solid {
       height 0.2
       poleGap 0.09
       poleRadius 0.05
-      poleAppearance PaintedWood {
+      poleAppearance RoughPine {
       }
       path [
         0 0 0
@@ -794,7 +794,7 @@ DEF FLOWERS Solid {
       height 0.2
       poleGap 0.09
       poleRadius 0.05
-      poleAppearance PaintedWood {
+      poleAppearance RoughPine {
       }
       path [
         0 0 0
@@ -846,7 +846,7 @@ Fence {
   height 0.4
   poleGap 0.35
   poleRadius 0.2
-  poleAppearance PaintedWood {
+  poleAppearance RoughPine {
   }
   path [
     0 0 0
@@ -951,7 +951,7 @@ Fence {
   height 0.3
   poleGap 0.35
   poleRadius 0.2
-  poleAppearance PaintedWood {
+  poleAppearance RoughPine {
   }
   path [
     0 0 0
@@ -2197,7 +2197,20 @@ Transform {
   translation 382.273 0.005 -334.983
   rotation 0 -1 0 5.07979
   children [
-    USE BUS_SIGNS
+    DEF BUS_SIGNS Shape {
+      appearance PBRAppearance {
+        baseColorMap ImageTexture {
+          url [
+            "textures/bus_lines.png"
+          ]
+        }
+        roughness 1
+        metalness 0
+      }
+      geometry Plane {
+        size 3.5 18
+      }
+    }
   ]
 }
 BusStop {
@@ -2210,7 +2223,20 @@ Transform {
   translation 537.645 0.005 -339.349
   rotation 0 1 0 2.45
   children [
-    USE BUS_SIGNS
+    DEF BUS_SIGNS Shape {
+      appearance PBRAppearance {
+        baseColorMap ImageTexture {
+          url [
+            "textures/bus_lines.png"
+          ]
+        }
+        roughness 1
+        metalness 0
+      }
+      geometry Plane {
+        size 3.5 18
+      }
+    }
   ]
 }
 BusStop {
@@ -2229,7 +2255,20 @@ Transform {
   translation 650.534 0.005 -281.79
   rotation 0 1 0 2.92
   children [
-    USE BUS_SIGNS
+    DEF BUS_SIGNS Shape {
+      appearance PBRAppearance {
+        baseColorMap ImageTexture {
+          url [
+            "textures/bus_lines.png"
+          ]
+        }
+        roughness 1
+        metalness 0
+      }
+      geometry Plane {
+        size 3.5 18
+      }
+    }
   ]
 }
 BusStop {
@@ -2241,7 +2280,20 @@ Transform {
   translation 602.452 0.005 -108.757
   rotation 0 1 0 1.83159
   children [
-    USE BUS_SIGNS
+    DEF BUS_SIGNS Shape {
+      appearance PBRAppearance {
+        baseColorMap ImageTexture {
+          url [
+            "textures/bus_lines.png"
+          ]
+        }
+        roughness 1
+        metalness 0
+      }
+      geometry Plane {
+        size 3.5 18
+      }
+    }
   ]
 }
 BusStop {
@@ -2253,7 +2305,20 @@ Transform {
   translation 532.623 0.005 -183.693
   rotation 0 -1 0 1.13
   children [
-    USE BUS_SIGNS
+    DEF BUS_SIGNS Shape {
+      appearance PBRAppearance {
+        baseColorMap ImageTexture {
+          url [
+            "textures/bus_lines.png"
+          ]
+        }
+        roughness 1
+        metalness 0
+      }
+      geometry Plane {
+        size 3.5 18
+      }
+    }
   ]
 }
 BusStop {
@@ -2265,7 +2330,20 @@ Transform {
   translation 570.124 0.005 -104.304
   rotation 0 -1 0 1.35
   children [
-    USE BUS_SIGNS
+    DEF BUS_SIGNS Shape {
+      appearance PBRAppearance {
+        baseColorMap ImageTexture {
+          url [
+            "textures/bus_lines.png"
+          ]
+        }
+        roughness 1
+        metalness 0
+      }
+      geometry Plane {
+        size 3.5 18
+      }
+    }
   ]
 }
 BusStop {
@@ -2277,7 +2355,20 @@ Transform {
   translation 521.419 0.005 -174.589
   rotation 0 1 0 1.9792
   children [
-    USE BUS_SIGNS
+    DEF BUS_SIGNS Shape {
+      appearance PBRAppearance {
+        baseColorMap ImageTexture {
+          url [
+            "textures/bus_lines.png"
+          ]
+        }
+        roughness 1
+        metalness 0
+      }
+      geometry Plane {
+        size 3.5 18
+      }
+    }
   ]
 }
 SimpleBuilding {

--- a/projects/vehicles/worlds/village_realistic.wbt
+++ b/projects/vehicles/worlds/village_realistic.wbt
@@ -3842,7 +3842,7 @@ DEF RIVER Transform {
   children [
     Shape {
       appearance PBRAppearance {
-        baseColor 0.17 0.45 0.7
+        baseColor 0.2 0.3 0.45
         metalness 0
       }
       geometry Extrusion {
@@ -3878,7 +3878,7 @@ DEF SMALL_LAKE Transform {
   children [
     DEF water Shape {
       appearance PBRAppearance {
-        baseColor 0.17 0.45 0.7
+        baseColor 0.2 0.3 0.45
         metalness 0
       }
       geometry IndexedFaceSet {
@@ -4056,7 +4056,7 @@ DEF BIG_LAKE Transform {
   children [
     DEF water Shape {
       appearance PBRAppearance {
-        baseColor 0.17 0.45 0.7
+        baseColor 0.2 0.3 0.45
         metalness 0
       }
       geometry IndexedFaceSet {

--- a/projects/vehicles/worlds/village_realistic.wbt
+++ b/projects/vehicles/worlds/village_realistic.wbt
@@ -106,6 +106,8 @@ DEF GRASS Transform {
             "textures/grass.jpg"
           ]
         }
+        roughness 1
+        metalness 0
         textureTransform TextureTransform {
           scale 40 40
         }
@@ -139,12 +141,7 @@ Fence {
   height 0.4
   poleGap 0.35
   poleRadius 0.2
-  poleAppearance PBRAppearance {
-    baseColorMap ImageTexture {
-      url [
-        "textures/wood.jpg"
-      ]
-    }
+  poleAppearance PaintedWood {
   }
   path [
     4.4 0 0.7
@@ -169,12 +166,7 @@ DEF FLOWERS Solid {
       height 0.2
       poleGap 0.09
       poleRadius 0.05
-      poleAppearance PBRAppearance {
-        baseColorMap ImageTexture {
-          url [
-            "textures/wood.jpg"
-          ]
-        }
+      poleAppearance PaintedWood {
       }
       path [
         0 0 0
@@ -192,6 +184,8 @@ DEF FLOWERS Solid {
             "textures/flowers_purple.jpg"
           ]
         }
+        roughness 1
+        metalness 0
         textureTransform TextureTransform {
           scale 10 5
         }
@@ -220,12 +214,7 @@ DEF FLOWERS Solid {
       height 0.2
       poleGap 0.09
       poleRadius 0.05
-      poleAppearance PBRAppearance {
-        baseColorMap ImageTexture {
-          url [
-            "textures/wood.jpg"
-          ]
-        }
+      poleAppearance PaintedWood {
       }
       path [
         0 0 0
@@ -243,6 +232,8 @@ DEF FLOWERS Solid {
             "textures/flowers_purple.jpg"
           ]
         }
+        roughness 1
+        metalness 0
         textureTransform TextureTransform {
           scale 10 5
         }
@@ -754,12 +745,7 @@ DEF FLOWERS Solid {
       height 0.2
       poleGap 0.09
       poleRadius 0.05
-      poleAppearance PBRAppearance {
-        baseColorMap ImageTexture {
-          url [
-            "textures/wood.jpg"
-          ]
-        }
+      poleAppearance PaintedWood {
       }
       path [
         0 0 0
@@ -777,6 +763,8 @@ DEF FLOWERS Solid {
             "textures/flowers_purple.jpg"
           ]
         }
+        roughness 1
+        metalness 0
         textureTransform TextureTransform {
           scale 10 5
         }
@@ -806,12 +794,7 @@ DEF FLOWERS Solid {
       height 0.2
       poleGap 0.09
       poleRadius 0.05
-      poleAppearance PBRAppearance {
-        baseColorMap ImageTexture {
-          url [
-            "textures/wood.jpg"
-          ]
-        }
+      poleAppearance PaintedWood {
       }
       path [
         0 0 0
@@ -829,6 +812,8 @@ DEF FLOWERS Solid {
             "textures/flowers_yellow.jpg"
           ]
         }
+        roughness 1
+        metalness 0
         textureTransform TextureTransform {
           scale 10 5
         }
@@ -861,12 +846,7 @@ Fence {
   height 0.4
   poleGap 0.35
   poleRadius 0.2
-  poleAppearance PBRAppearance {
-    baseColorMap ImageTexture {
-      url [
-        "textures/wood.jpg"
-      ]
-    }
+  poleAppearance PaintedWood {
   }
   path [
     0 0 0
@@ -887,6 +867,8 @@ DEF GRASS2 Transform {
             "textures/grass.jpg"
           ]
         }
+        roughness 1
+        metalness 0
         textureTransform TextureTransform {
           scale 40 40
         }
@@ -933,6 +915,8 @@ DEF GRASS3 Transform {
             "textures/grass.jpg"
           ]
         }
+        roughness 1
+        metalness 0
         textureTransform TextureTransform {
           scale 40 40
         }
@@ -967,12 +951,7 @@ Fence {
   height 0.3
   poleGap 0.35
   poleRadius 0.2
-  poleAppearance PBRAppearance {
-    baseColorMap ImageTexture {
-      url [
-        "textures/wood.jpg"
-      ]
-    }
+  poleAppearance PaintedWood {
   }
   path [
     0 0 0
@@ -2183,6 +2162,8 @@ BusStop {
   translation 418.69 0 -232.169
   rotation 0 -1 0 3.10841
   appearance PBRAppearance {
+    roughness 1
+    metalness 0
   }
 }
 Transform {
@@ -2208,6 +2189,8 @@ BusStop {
   rotation 0 1 0 2.77419
   name "bus stop(1)"
   appearance PBRAppearance {
+    roughness 1
+    metalness 0
   }
 }
 BusSimple {
@@ -2240,6 +2223,8 @@ BusStop {
   name "bus stop(2)"
   bench FALSE
   appearance PBRAppearance {
+    roughness 1
+    metalness 0
   }
 }
 Transform {
@@ -2266,6 +2251,8 @@ BusStop {
   name "bus stop(3)"
   bench FALSE
   appearance PBRAppearance {
+    roughness 1
+    metalness 0
   }
 }
 BusSimple {
@@ -2297,6 +2284,8 @@ BusStop {
   rotation 0 -1 0 2.85841
   name "bus stop(4)"
   appearance PBRAppearance {
+    roughness 1
+    metalness 0
   }
 }
 Transform {
@@ -2322,6 +2311,8 @@ BusStop {
   rotation 0 -1 0 5.82478
   name "bus stop(5)"
   appearance PBRAppearance {
+    roughness 1
+    metalness 0
   }
 }
 Transform {
@@ -2347,6 +2338,8 @@ BusStop {
   rotation 7.13274e-08 -1 -2.86931e-08 6.02478
   name "bus stop(6)"
   appearance PBRAppearance {
+    roughness 1
+    metalness 0
   }
 }
 Transform {
@@ -2372,6 +2365,8 @@ BusStop {
   rotation 0 -1 0 2.73319
   name "bus stop(7)"
   appearance PBRAppearance {
+    roughness 1
+    metalness 0
   }
 }
 Transform {
@@ -2445,6 +2440,8 @@ BungalowStyleHouse {
   rotation 0 1 0 2.8798
   name "bungalow style house(1)"
   appearance PBRAppearance {
+    roughness 1
+    metalness 0
   }
 }
 BungalowStyleHouse {
@@ -2452,6 +2449,8 @@ BungalowStyleHouse {
   rotation 0 1 0 6.02139
   name "bungalow style house(2)"
   appearance PBRAppearance {
+    roughness 1
+    metalness 0
   }
 }
 BungalowStyleHouse {
@@ -2466,6 +2465,8 @@ BungalowStyleHouse {
   fence FALSE
   floor FALSE
   appearance PBRAppearance {
+    roughness 1
+    metalness 0
   }
 }
 BungalowStyleHouse {
@@ -2474,6 +2475,8 @@ BungalowStyleHouse {
   name "bungalow style house(5)"
   floor FALSE
   appearance PBRAppearance {
+    roughness 1
+    metalness 0
   }
 }
 Fence {
@@ -3548,6 +3551,8 @@ BungalowStyleHouse {
   floor FALSE
   chimney FALSE
   appearance PBRAppearance {
+    roughness 1
+    metalness 0
   }
 }
 Auditorium {
@@ -3571,6 +3576,8 @@ ModernHouse {
   translation 688.344 0.005 -205.429
   rotation 0 1 0 3.40339
   appearance PBRAppearance {
+    roughness 1
+    metalness 0
   }
 }
 FastFoodRestaurant {
@@ -3624,6 +3631,8 @@ Fence {
   name "fence(6)"
   height 2
   poleAppearance DEF APPEARANCE PBRAppearance {
+    roughness 1
+    metalness 0
   }
   path [
     0 0 0
@@ -3659,6 +3668,8 @@ Fence {
   name "fence(7)"
   height 2
   poleAppearance DEF APPEARANCE PBRAppearance {
+    roughness 1
+    metalness 0
   }
   path [
     0 0 0
@@ -3680,6 +3691,8 @@ Fence {
   name "fence(8)"
   height 2
   poleAppearance DEF APPEARANCE PBRAppearance {
+    roughness 1
+    metalness 0
   }
   path [
     0 0 0
@@ -3702,6 +3715,8 @@ Fence {
   name "fence(9)"
   height 2
   poleAppearance DEF APPEARANCE PBRAppearance {
+    roughness 1
+    metalness 0
   }
   path [
     0 0 0
@@ -3724,6 +3739,8 @@ Fence {
   name "fence(10)"
   height 2
   poleAppearance DEF APPEARANCE PBRAppearance {
+    roughness 1
+    metalness 0
   }
   path [
     0 0 0
@@ -3744,6 +3761,8 @@ ModernHouse {
   rotation 0 -1 0 4.45059
   name "modern house(1)"
   appearance PBRAppearance {
+    roughness 1
+    metalness 0
   }
 }
 ModernHouse {
@@ -3755,6 +3774,8 @@ ModernHouse {
   rotation 0 1 0 5.75959
   name "modern house(3)"
   appearance PBRAppearance {
+    roughness 1
+    metalness 0
   }
 }
 ModernHouse {
@@ -3762,12 +3783,16 @@ ModernHouse {
   rotation 0 1 0 6.28319
   name "modern house(4)"
   appearance PBRAppearance {
+    roughness 1
+    metalness 0
   }
 }
 SimpleTwoFloorsHouse {
   translation 490.775 0.005 -150.418
   rotation 0 1 0 1.8326
   appearance PBRAppearance {
+    roughness 1
+    metalness 0
   }
 }
 SimpleTwoFloorsHouse {
@@ -3775,6 +3800,8 @@ SimpleTwoFloorsHouse {
   rotation 0 1 0 6.02139
   name "simple two floors house(1)"
   appearance PBRAppearance {
+    roughness 1
+    metalness 0
   }
 }
 SimpleTwoFloorsHouse {
@@ -3815,6 +3842,16 @@ DEF RIVER Transform {
   children [
     Shape {
       appearance PBRAppearance {
+        baseColor 0.17 0.45 0.7
+        baseColorMap ImageTexture {
+          url [
+            "textures/water.jpg"
+          ]
+        }
+        metalness 0
+        textureTransform DEF SEA_TEXTURE_TRANSFORM TextureTransform {
+          scale 500 500
+        }
       }
       geometry Extrusion {
         crossSection [
@@ -3849,6 +3886,16 @@ DEF SMALL_LAKE Transform {
   children [
     DEF water Shape {
       appearance PBRAppearance {
+        baseColor 0.17 0.45 0.7
+        baseColorMap ImageTexture {
+          url [
+            "textures/water.jpg"
+          ]
+        }
+        metalness 0
+        textureTransform DEF SEA_TEXTURE_TRANSFORM TextureTransform {
+          scale 500 500
+        }
       }
       geometry IndexedFaceSet {
         coord Coordinate {
@@ -4025,6 +4072,16 @@ DEF BIG_LAKE Transform {
   children [
     DEF water Shape {
       appearance PBRAppearance {
+        baseColor 0.17 0.45 0.7
+        baseColorMap ImageTexture {
+          url [
+            "textures/water.jpg"
+          ]
+        }
+        metalness 0
+        textureTransform DEF SEA_TEXTURE_TRANSFORM TextureTransform {
+          scale 500 500
+        }
       }
       geometry IndexedFaceSet {
         coord Coordinate {

--- a/projects/vehicles/worlds/village_realistic.wbt
+++ b/projects/vehicles/worlds/village_realistic.wbt
@@ -2424,6 +2424,7 @@ BungalowStyleHouse {
   rotation 0 1 0 2.8798
   name "bungalow style house(1)"
   appearance PBRAppearance {
+    baseColor 0.726238 0.497505 0.773327
     roughness 1
     metalness 0
   }
@@ -2433,6 +2434,7 @@ BungalowStyleHouse {
   rotation 0 1 0 6.02139
   name "bungalow style house(2)"
   appearance PBRAppearance {
+    baseColor 0.726238 0.497505 0.773327
     roughness 1
     metalness 0
   }
@@ -2449,6 +2451,7 @@ BungalowStyleHouse {
   fence FALSE
   floor FALSE
   appearance PBRAppearance {
+    baseColor 0.664195 0.815122 0.820005
     roughness 1
     metalness 0
   }
@@ -3533,6 +3536,7 @@ BungalowStyleHouse {
   floor FALSE
   chimney FALSE
   appearance PBRAppearance {
+    baseColor 0.669993 0.212161 0.212161
     roughness 1
     metalness 0
   }
@@ -3558,6 +3562,7 @@ ModernHouse {
   translation 688.344 0.005 -205.429
   rotation 0 1 0 3.40339
   appearance PBRAppearance {
+    baseColor 0.796674 0.545708 0.419577
     roughness 1
     metalness 0
   }
@@ -3743,6 +3748,7 @@ ModernHouse {
   rotation 0 -1 0 4.45059
   name "modern house(1)"
   appearance PBRAppearance {
+    baseColor 0.45098 0.619608 0.811765
     roughness 1
     metalness 0
   }
@@ -3756,6 +3762,7 @@ ModernHouse {
   rotation 0 1 0 5.75959
   name "modern house(3)"
   appearance PBRAppearance {
+    baseColor 0.820005 0.579461 0.579461
     roughness 1
     metalness 0
   }
@@ -3765,6 +3772,7 @@ ModernHouse {
   rotation 0 1 0 6.28319
   name "modern house(4)"
   appearance PBRAppearance {
+    baseColor 0.747494 0.85333 0.685512
     roughness 1
     metalness 0
   }
@@ -3773,6 +3781,7 @@ SimpleTwoFloorsHouse {
   translation 490.775 0.005 -150.418
   rotation 0 1 0 1.8326
   appearance PBRAppearance {
+    baseColor 0.726238 0.497505 0.773327
     roughness 1
     metalness 0
   }
@@ -3782,6 +3791,7 @@ SimpleTwoFloorsHouse {
   rotation 0 1 0 6.02139
   name "simple two floors house(1)"
   appearance PBRAppearance {
+    baseColor 0.796674 0.545708 0.419577
     roughness 1
     metalness 0
   }


### PR DESCRIPTION
This world has not been updated regarding to default roughness and metalness:

| Before | After |
| --- | --- |
| ![village_realistic](https://user-images.githubusercontent.com/866788/61879399-3d492300-aef3-11e9-99dc-73b87f196cdc.png) | ![village_realistic_1](https://user-images.githubusercontent.com/866788/61879397-3cb08c80-aef3-11e9-905e-d695e5a39c58.png) |
