### PR TITLE
webots.min.js: Compute normals for ElevationGrids

### DIFF
--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -13,7 +13,7 @@ Released on XXX YYth, 2019.
     - Added new samples about the [Accelerometer](../guide/samples-devices.md#accelerometer-wbt) and [Brake](../guide/samples-devices.md#brake-wbt) devices.
   - Bug fixes
     - Webots online 3D viewer (`webots.min.js`)
-      - Fixed ElevationGrid normals
+      - Fixed [ElevationGrid](elevationgrid.md) normals.
     - Fixed `realistic_village.wbt` materials.
     - Fixed the insertion of a PROTO containing a [BallJoint](balljoint.md).
     - Fixed ros controller not publishing the `/connector/presence` topic.

--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -12,6 +12,8 @@ Released on XXX YYth, 2019.
   - New Samples
     - Added new samples about the [Accelerometer](../guide/samples-devices.md#accelerometer-wbt) and [Brake](../guide/samples-devices.md#brake-wbt) devices.
   - Bug fixes
+    - Webots online 3D viewer (`webots.min.js`)
+      - Fixed ElevationGrid normals
     - Fixed `realistic_village.wbt` materials.
     - Fixed the insertion of a PROTO containing a [BallJoint](balljoint.md).
     - Fixed ros controller not publishing the `/connector/presence` topic.

--- a/resources/web/wwi/x3d.js
+++ b/resources/web/wwi/x3d.js
@@ -656,6 +656,8 @@ THREE.X3DLoader = class X3DLoader {
       }
     }
 
+    geometry.computeVertexNormals();
+
     return geometry;
   }
 


### PR DESCRIPTION
| Webots | revision | this branch |
| --- | --- | --- |
| <img width="881" alt="bb-8 webots" src="https://user-images.githubusercontent.com/866788/62050463-8d84f580-b211-11e9-8d6a-2dcbdd65d47c.png"> | <img width="768" alt="bb-8 revision" src="https://user-images.githubusercontent.com/866788/62050462-8d84f580-b211-11e9-97d7-c48eb47392f5.png"> | <img width="768" alt="bb-8 pr" src="https://user-images.githubusercontent.com/866788/62050461-8d84f580-b211-11e9-83c5-d5ca662d3cc1.png"> |
| ![webots](https://user-images.githubusercontent.com/866788/62050466-8e1d8c00-b211-11e9-821b-f5813695d9ce.png) | <img width="636" alt="revision" src="https://user-images.githubusercontent.com/866788/62050465-8e1d8c00-b211-11e9-9d14-b1a185e4fea9.png"> | <img width="640" alt="pr" src="https://user-images.githubusercontent.com/866788/62050464-8d84f580-b211-11e9-9ef9-ef991c5b20de.png"> |






