### PR TITLE
webots.min.js: Fix background color

### DIFF
--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -14,6 +14,7 @@ Released on XXX YYth, 2019.
   - Bug fixes
     - Webots online 3D viewer (`webots.min.js`)
       - Fixed [ElevationGrid](elevationgrid.md) normals.
+      - Fixed [Background](background.md) default color.
     - Fixed `realistic_village.wbt` materials.
     - Fixed the insertion of a PROTO containing a [BallJoint](balljoint.md).
     - Fixed ros controller not publishing the `/connector/presence` topic.

--- a/resources/web/wwi/x3d_scene.js
+++ b/resources/web/wwi/x3d_scene.js
@@ -437,7 +437,7 @@ class X3dScene { // eslint-disable-line no-unused-vars
   _setupEnvironmentMap() {
     var isHDR = false;
     var backgroundMap;
-    if (typeof this.scene.background !== 'undefined') {
+    if (this.scene.background) {
       if (typeof this.scene.background.userData !== 'undefined' && this.scene.background.userData.isHDR) {
         isHDR = true;
         backgroundMap = this.scene.background.userData.texture;

--- a/resources/web/wwi/x3d_scene.js
+++ b/resources/web/wwi/x3d_scene.js
@@ -101,7 +101,7 @@ class X3dScene { // eslint-disable-line no-unused-vars
     this.objectsIdCache = {};
     this.useNodeCache = {};
     this.root = undefined;
-    this.scene.background = undefined;
+    this.scene.background = new THREE.Color(0, 0, 0);
     this.onSceneUpdate();
     this.render();
   }


### PR DESCRIPTION
- [x] Fix JS crash in case there is no background node (cf. above to reproduce the bug)
- [x] Fix the default Background color (black in Webots, white in threejs)
- [x] Log

### To reproduce the bug

- Open `physically_based_rendering.wbt`
- Remove the background
- Open the browser client
- Get this error when picking:
        <img width="373" alt="Capture d’écran 2019-07-29 à 15 34 17" src="https://user-images.githubusercontent.com/866788/62053614-464e3300-b218-11e9-94fe-40eadd8ccbf2.png">

Note:  `threejs` do the assumption that the background is null at several locations, for example [here](https://github.com/mrdoob/three.js/blob/r104/src/scenes/Scene.js#L31).