### PR TITLE
Hotfix modal window images background issues

### DIFF
--- a/docs/css/webots-doc.css
+++ b/docs/css/webots-doc.css
@@ -377,6 +377,7 @@ body {
   display: block;
   cursor: pointer;
   transition: 0.05s;
+  background-color: white;
 }
 .webots-doc .modal-window-close-button {
   position: absolute;


### PR DESCRIPTION
Solution: Add a white background in every modal window images.

Preview on some cases:

- Cylinder schema:
    - before: https://www.cyberbotics.com/doc/reference/cylinder
    - after: https://www.cyberbotics.com/doc/reference/cylinder?version=hotfix-modal-window-background-color
- Hinge2Joint schema:
    - before: https://www.cyberbotics.com/doc/reference/hinge2joint
    - after: https://www.cyberbotics.com/doc/reference/hinge2joint?version=hotfix-modal-window-background-color
- generated images with shadows:
    - before: https://www.cyberbotics.com/doc/guide/lidar-sensors
    - after: https://www.cyberbotics.com/doc/guide/lidar-sensors?version=hotfix-modal-window-background-color
