### PR TITLE
New HDR background

### DIFF
--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -9,6 +9,7 @@ Released on XXX YYth, 2019.
     - Added a new `fastHelixThreshold` field to the [Propeller](propeller.md) node to define when the helix representation is switched from `slowHelix` to` fastHelix`.
     - Added several appearances: `BlanketFabric`, `BrushedSteel`, `CarpetFabric`, `CementTiles`, `LedStrip`, `MarbleTiles`, `PorcelainChevronTiles`, `ReflectiveSurface` and `SlatePavement`.
     - Added several bathroom objects and lights: `BathroomSink`, `Bathtube`, `Toilet`, `WashingMachine`, `CeilingSpotLight` and `ConstructionLamp`.
+    - Added a new HDR background: `noon_cloudy_countryside`
   - New Samples
     - Added new samples about the [Accelerometer](../guide/samples-devices.md#accelerometer-wbt) and [Brake](../guide/samples-devices.md#brake-wbt) devices.
   - Bug fixes

--- a/projects/objects/backgrounds/protos/TexturedBackground.proto
+++ b/projects/objects/backgrounds/protos/TexturedBackground.proto
@@ -22,7 +22,7 @@
 # - mountains (HDR)
 
 PROTO TexturedBackground [
-  field  SFString{"dawn_cloudy_empty", "empty_office", "factory", "morning_cloudy_countryside", "morning_cloudy_empty", "noon_building_overcast", "noon_cloudy_empty", "noon_cloudy_mountains", "noon_park_empty", "noon_stormy_empty", "noon_sunny_empty", "noon_sunny_garden", "twilight_cloudy_empty", "mountains"}
+  field  SFString{"dawn_cloudy_empty", "empty_office", "factory", "morning_cloudy_empty", "noon_building_overcast", "noon_cloudy_countryside", "noon_cloudy_empty", "noon_cloudy_mountains", "noon_park_empty", "noon_stormy_empty", "noon_sunny_empty", "noon_sunny_garden", "twilight_cloudy_empty", "mountains"}
                   texture "mountains"  # Defines the texture of the background.
 ]
 {

--- a/projects/objects/backgrounds/protos/TexturedBackground.proto
+++ b/projects/objects/backgrounds/protos/TexturedBackground.proto
@@ -11,6 +11,7 @@
 # - factory (HDR)
 # - morning_cloudy_empty
 # - noon_building_overcast (HDR)
+# - noon_cloudy_countryside (HDR)
 # - noon_cloudy_empty
 # - noon_cloudy_mountains
 # - noon_park_empty (HDR)
@@ -21,7 +22,8 @@
 # - mountains (HDR)
 
 PROTO TexturedBackground [
-  field  SFString{"dawn_cloudy_empty", "empty_office", "factory", "morning_cloudy_empty", "noon_building_overcast", "noon_cloudy_empty", "noon_cloudy_mountains", "noon_park_empty", "noon_stormy_empty", "noon_sunny_empty", "noon_sunny_garden", "twilight_cloudy_empty", "mountains"} texture "mountains"  # Defines the texture of the background.
+  field  SFString{"dawn_cloudy_empty", "empty_office", "factory", "morning_cloudy_countryside", "morning_cloudy_empty", "noon_building_overcast", "noon_cloudy_empty", "noon_cloudy_mountains", "noon_park_empty", "noon_stormy_empty", "noon_sunny_empty", "noon_sunny_garden", "twilight_cloudy_empty", "mountains"}
+                  texture "mountains"  # Defines the texture of the background.
 ]
 {
   Background {

--- a/projects/objects/backgrounds/protos/TexturedBackgroundLight.proto
+++ b/projects/objects/backgrounds/protos/TexturedBackgroundLight.proto
@@ -11,6 +11,7 @@
 # - factory
 # - morning_cloudy_empty
 # - noon_building_overcast
+# - noon_cloudy_countryside
 # - noon_cloudy_empty
 # - noon_cloudy_mountains
 # - noon_park_empty
@@ -21,7 +22,7 @@
 # - mountains
 
 PROTO TexturedBackgroundLight [
-  field  SFString{"dawn_cloudy_empty", "empty_office", "factory", "morning_cloudy_empty", "noon_building_overcast", "noon_cloudy_empty", "noon_cloudy_mountains", "noon_park_empty", "noon_stormy_empty", "noon_sunny_empty", "noon_sunny_garden", "twilight_cloudy_empty", "mountains"}
+  field  SFString{"dawn_cloudy_empty", "empty_office", "factory", "morning_cloudy_countryside", "morning_cloudy_empty", "noon_building_overcast", "noon_cloudy_empty", "noon_cloudy_mountains", "noon_park_empty", "noon_stormy_empty", "noon_sunny_empty", "noon_sunny_garden", "twilight_cloudy_empty", "mountains"}
                   texture        "mountains"  # Should be equivalent to the 'texture' field of the TexturedBackground.
   field  SFBool   castShadows    TRUE         # Defines whether the light should cast shadows.
 ]
@@ -44,6 +45,10 @@ PROTO TexturedBackgroundLight [
       intensity = 0.9
     elseif fields.texture.value == "noon_building_overcast" or fields.texture.value == "factory" then
       on = false
+    elseif fields.texture.value == "noon_cloudy_countryside" then
+      direction = {-0.3, -1, -0.1}
+      color = {0.95, 0.95, 1.0}
+      intensity = 3.0
     elseif fields.texture.value == "noon_cloudy_empty" then
       direction = {0.2, -1, 0.2}
       color = {0.9, 0.9, 1.0}

--- a/projects/objects/backgrounds/protos/TexturedBackgroundLight.proto
+++ b/projects/objects/backgrounds/protos/TexturedBackgroundLight.proto
@@ -22,7 +22,7 @@
 # - mountains
 
 PROTO TexturedBackgroundLight [
-  field  SFString{"dawn_cloudy_empty", "empty_office", "factory", "morning_cloudy_countryside", "morning_cloudy_empty", "noon_building_overcast", "noon_cloudy_empty", "noon_cloudy_mountains", "noon_park_empty", "noon_stormy_empty", "noon_sunny_empty", "noon_sunny_garden", "twilight_cloudy_empty", "mountains"}
+  field  SFString{"dawn_cloudy_empty", "empty_office", "factory", "morning_cloudy_empty", "noon_building_overcast", "noon_cloudy_countryside", "noon_cloudy_empty", "noon_cloudy_mountains", "noon_park_empty", "noon_stormy_empty", "noon_sunny_empty", "noon_sunny_garden", "twilight_cloudy_empty", "mountains"}
                   texture        "mountains"  # Should be equivalent to the 'texture' field of the TexturedBackground.
   field  SFBool   castShadows    TRUE         # Defines whether the light should cast shadows.
 ]


### PR DESCRIPTION
I think we missed an HDR outdoor background take at noon with patterns in the sky (clouds) to increase reflection effects on the reflective materials.

This one seems to solve this issue:

![city](https://user-images.githubusercontent.com/866788/62457695-a21a3e00-b77b-11e9-88d9-bad4f7370f8c.png)

Comparison on a car:

| HDR background | Result |
| --- | --- |
| `moutains` (default) | ![mountains](https://user-images.githubusercontent.com/866788/62457696-a21a3e00-b77b-11e9-9927-3a854afa5790.png) |
| `noon_cloudy_countryside` (new) | ![noon_cloudy_countryside](https://user-images.githubusercontent.com/866788/62457698-a2b2d480-b77b-11e9-80ae-1a1e3539b4f6.png) |