### PR TITLE
Modal images dimension

### DIFF
--- a/docs/css/webots-doc.css
+++ b/docs/css/webots-doc.css
@@ -374,6 +374,8 @@ body {
 }
 .webots-doc .modal-window-image-content {
   margin: auto;
+  max-height: 80%;
+  max-width: 90%;
   display: block;
   cursor: pointer;
   transition: 0.05s;


### PR DESCRIPTION
Currently, the modal images are limited with the doc images max-height = 500px.

- https://cyberbotics.com/doc/guide/samples-environments

When the image is big, If the window is too small, the image is cut, it is too big the image is limited to a height of 500px.
Setting explicitly the max dimension as a percentage of the parent modal window solves these 2 issues:

- https://cyberbotics.com/doc/guide/samples-environments?version=enhancement-modal-window-image-size