### PR TITLE
Fixed Installation instructions

### DIFF
--- a/docs/guide/installation-procedure.md
+++ b/docs/guide/installation-procedure.md
@@ -41,7 +41,8 @@ First of all, you may want to configure your APT package manager by adding the C
 Simply execute the following lines:
 
 ```sh
-apt-add-repository 'deb http://www.cyberbotics.com/debian/ binary-amd64/'
+sudo su -
+apt-add-repository 'deb https://www.cyberbotics.com/debian/ binary-amd64/'
 apt-get update
 ```
 
@@ -49,17 +50,17 @@ As an alternative, you can easily add the Cyberbotics repository from the `Softw
 In the `Other Software` tab, click on the `Add...` button and copy the following line:
 
 ```text
-deb http://www.cyberbotics.com/debian/ binary-amd64/
+deb https://www.cyberbotics.com/debian/ binary-amd64/
 ```
 
-When you will close the window, the APT packages list should be automatically updated.
+When you close the window, the APT packages list should be automatically updated.
 Otherwise you can manually execute the following command:
 
 ```sh
 apt-get update
 ```
 
-Optionally, Webots can be authentified thanks to the `Cyberbotics.asc` signature file which can be downloaded [here](http://www.cyberbotics.com/linux), using this command:
+Webots should be authenticated with the [Cyberbotics.asc](https://www.cyberbotics.com/Cyberbotics.asc) signature file which can be downloaded from the [Webots download page](https://www.cyberbotics.com/download), and installed using this command:
 
 ```sh
 apt-key add /path/to/Cyberbotics.asc
@@ -71,8 +72,7 @@ Then proceed to the installation of Webots using:
 apt-get install webots
 ```
 
-> **Note**: This procedure can also be done using any APT front-end tools such as the Synaptic Package Manager.
-But only a command line procedure is documented here.
+> **Note**: Although only the command line procedure is documented here, it is also possible to use any APT front-end tool, such as the Synaptic Package Manager, to proceed with the APT installation of Webots.
 
 #### From the "tarball" Package
 

--- a/docs/guide/installation-procedure.md
+++ b/docs/guide/installation-procedure.md
@@ -34,14 +34,23 @@ The package names could slightly change on different releases and distributions.
 
 #### Using Advanced Packaging Tool (APT)
 
-The advantage of this solution is that Webots will be updated with the system updates.
-This installation requires the `root` privileges.
-
-First of all, you may want to configure your APT package manager by adding the Cyberbotics repository.
-Simply execute the following lines:
+The advantage of this solution is that Webots will be updated automatically with system updates.
+This installation requires the `root` privileges which you can acquire from this command:
 
 ```sh
 sudo su -
+```
+
+First of all, Webots should be authenticated with the [Cyberbotics.asc](https://www.cyberbotics.com/Cyberbotics.asc) signature file which can be downloaded from the [Webots download page](https://www.cyberbotics.com/download), and installed using this command:
+
+```sh
+apt-key add /path/to/Cyberbotics.asc
+```
+
+Then, you can configure your APT package manager by adding the Cyberbotics repository.
+Simply execute the following lines:
+
+```sh
 apt-add-repository 'deb https://www.cyberbotics.com/debian/ binary-amd64/'
 apt-get update
 ```
@@ -58,12 +67,6 @@ Otherwise you can manually execute the following command:
 
 ```sh
 apt-get update
-```
-
-Webots should be authenticated with the [Cyberbotics.asc](https://www.cyberbotics.com/Cyberbotics.asc) signature file which can be downloaded from the [Webots download page](https://www.cyberbotics.com/download), and installed using this command:
-
-```sh
-apt-key add /path/to/Cyberbotics.asc
 ```
 
 Then proceed to the installation of Webots using:


### PR DESCRIPTION
Use the https protocol instead of http.
The signature file is mandatory, not optional.
Improved English.

👍