### PR TITLE
webots.min.js: fix authenticated user check

### DIFF
--- a/resources/web/wwi/editor.js
+++ b/resources/web/wwi/editor.js
@@ -122,7 +122,7 @@ class Editor extends DialogWindow { // eslint-disable-line no-unused-vars
     if ($('#filename-' + i).html().endsWith('*')) { // file was modified
       $('#filename-' + i).html(this.filenames[i]);
       this.needToUploadFiles[i] = true;
-      if (webots.User1Id !== '' && webots.User1Authentication !== '') // user logged in
+      if ((typeof webots.User1Id !== 'undefined' || webots.User1Id !== '') && webots.User1Authentication) // user logged in
         this._storeUserFile(i);
       else
         this.unloggedFileModified = true;
@@ -149,7 +149,7 @@ class Editor extends DialogWindow { // eslint-disable-line no-unused-vars
       this.sessions[index].setValue(content);
       if ($('#filename-' + index).html().endsWith('*'))
         $('#filename-' + index).html(filename);
-      if (webots.User1Authentication !== '' && webots.User1Id !== '')
+      if (webots.User1Authentication && (typeof webots.User1Id !== 'undefined' || webots.User1Id !== ''))
         this.storeUserFile(index);
       return;
     }

--- a/resources/web/wwi/toolbar.js
+++ b/resources/web/wwi/toolbar.js
@@ -168,7 +168,7 @@ class Toolbar { // eslint-disable-line no-unused-vars
   requestQuit() {
     if (this.view.editor.hasUnsavedChanges()) {
       var text;
-      if (this.view.editor.unloggedFileModified || webots.User1Id === '')
+      if (this.view.editor.unloggedFileModified || typeof webots.User1Id === 'undefined' || webots.User1Id === '')
         text = 'Your changes to the robot controller will be lost because you are not logged in.';
       else
         text = 'Your unsaved changes to the robot controller will be lost.';

--- a/resources/web/wwi/webots.js
+++ b/resources/web/wwi/webots.js
@@ -226,9 +226,9 @@ webots.View = class View {
         }
         if (windowName === infoWindowName) {
           var user;
-          if (webots.User1Id !== '') {
+          if (typeof webots.User1Id !== 'undefined' && webots.User1Id !== '') {
             user = ' [' + webots.User1Name;
-            if (webots.User2Id !== '')
+            if (typeof webots.User2Id !== 'undefined' && webots.User2Id !== '')
               user += '/' + webots.User2Name;
             user += ']';
           } else

--- a/resources/web/wwi/webots.js
+++ b/resources/web/wwi/webots.js
@@ -332,7 +332,7 @@ webots.View = class View {
     }
 
     if (typeof this.contextMenu === 'undefined' && this.isWebSocketProtocol) {
-      this.contextMenu = new ContextMenu(webots.User1Id !== '' && webots.User1Authentication !== '', this.view3D);
+      this.contextMenu = new ContextMenu((typeof webots.User1Id !== 'undefined' || webots.User1Id !== '') && webots.User1Authentication, this.view3D);
       this.contextMenu.onEditController = (controller) => { this.editController(controller); };
       this.contextMenu.onFollowObject = (id) => { this.x3dScene.viewpoint.follow(id); };
       this.contextMenu.isFollowedObject = (object3d, setResult) => { setResult(this.x3dScene.viewpoint.isFollowedObject(object3d)); };


### PR DESCRIPTION
When running others simulations, `webots.User1Authentication` was `undefined` and not an empty string as expected.
Because of this, it was possible to open the editor but the controller content was not displayed. 


I improved all the checks for user ids and authentication so that they do no longer depend on the previously executed functions.
In case of the user ids we should explicitly check for `undefined` and empty string, because otherwise user ID `0` will also be detected as undefined.