### PR TITLE
visual_tracking benchmark: fix URI of camera/display images

### DIFF
--- a/projects/samples/robotbenchmark/visual_tracking/controllers/visual_tracking/visual_tracking.py
+++ b/projects/samples/robotbenchmark/visual_tracking/controllers/visual_tracking/visual_tracking.py
@@ -45,8 +45,8 @@ def sendDeviceImage(robot, device):
         return
     with open(deviceImagePath + '/' + fileName, 'rb') as f:
         fileString = f.read()
-        fileString64 = base64.b64encode(fileString)
-        robot.wwiSendText("image[" + deviceName + "]:data:image/jpeg;base64," + str(fileString64))
+        fileString64 = base64.b64encode(fileString).decode()
+        robot.wwiSendText("image[" + deviceName + "]:data:image/jpeg;base64," + fileString64)
         f.close()
 
 


### PR DESCRIPTION
Fix the image URI sent to the robot window: in python 3 `base64.b64encode` creates a  bytes literal object that converted to string has the format `b'<value>'`.
The additional `b` and quotes was making the URI invalid.