### PR TITLE
Fix read controller python shebang

### DIFF
--- a/docs/guide/using-python.md
+++ b/docs/guide/using-python.md
@@ -17,9 +17,17 @@ Webots starts Python using the standard `python` command line.
 As a consequence, it executes the first `python` binary found in the current `PATH`.
 If you want to use a different version of Python, please install it if needed and configure your environment so that it becomes the default `python` version when called from the command line in a terminal.
 Alternatively, you can change the default Python command from the Webots Preferences in the General tab.
-If you set it for example to `python3.7` instead of `python`, this version of python will be used (if available from the command line).
-Finally, it is also possible to set a different version of Python for each robot controller by editing the `[python]` section of the `runtime.ini` file in each robot controller directory and setting the `COMMAND` value to `python3`, `python3.7` or `python2.7`, etc.
+If you set it for example to `python3.7` instead of `python`, this version of python will be used by default, if available from the command line.
+It is also possible to set a different version of Python for each robot controller by editing the `[python]` section of the `runtime.ini` file in each robot controller directory and setting the `COMMAND` value to `python3`, `python3.7` or `python2.7`, etc.
 If specified in the `runtime.ini` file of a controller, this Python command will be executed instead of the default one to launch this controller.
+On Linux and macOS, it is also possible to override this value by setting a standard Python shebang header line in your main python controller file, for example:
+
+```python
+#!/usr/bin/env python3.6
+```
+
+On Windows, the shebang header line option is not supported.
+However, it is parsed and a warning is displayed in case of mismatch, e.g., if the version specified on the shebang header line mismatches the actual version of Python used by Webots.
 
 #### Linux Installation
 

--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -24,6 +24,7 @@ Released on XXX YYth, 2019.
     - Fixed ros controller not publishing the `/connector/presence` topic.
     - Fixed crash when using an `infra-red` [DistanceSensors](distancesensor.md) pointing to a texture without repetition.
     - Fixed external controllers, now when a controller exits, the simulation keeps running and it is possible to re-start another external controller.
+    - Webots now reads the Python shebang of controller programs to determine which version of Python to execute.
 
 ## [Webots R2019b](../blog/Webots-2019-b-release.md)
 Released on June 25th, 2019.

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -490,7 +490,7 @@ void WbController::setProcessEnvironment() {
     QFile pythonSourceFile(mControllerPath + name() + ".py");
     if (pythonSourceFile.open(QIODevice::ReadOnly)) {
       QTextStream in(&pythonSourceFile);
-      QString line = in.readLine();
+      const QString &line = in.readLine();
       if (line.startsWith("#!")) {
 #ifndef _WIN32
         if (line.startsWith("#!/usr/bin/env "))

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -497,7 +497,7 @@ void WbController::setProcessEnvironment() {
         else
           mPythonCommand = WbLanguageTools::pythonCommand(mPythonShortVersion, line.mid(2).trimmed());
 #else  // Windows: check that the version specified in the shebang corresponds to the version of Python installed
-        const QString expectedVersion = line.mid(line.lastIndexOf("python", -1, Qt::CaseInsensitive) + 6);
+        const QString &expectedVersion = line.mid(line.lastIndexOf("python", -1, Qt::CaseInsensitive) + 6);
         bool mismatch = false;
         int l = expectedVersion.length();
         if (l == 1 && expectedVersion[0] != mPythonShortVersion[0])

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -497,17 +497,17 @@ void WbController::setProcessEnvironment() {
           mPythonCommand = WbLanguageTools::pythonCommand(mPythonShortVersion, line.mid(15).trimmed());
         else
           mPythonCommand = WbLanguageTools::pythonCommand(mPythonShortVersion, line.mid(2).trimmed());
-#else // Windows: check that the version specified in the shebang corresponds to the version of Python installed
+#else  // Windows: check that the version specified in the shebang corresponds to the version of Python installed
         expectedVersion = line.mid(line.lastIndexOf("python", -1, Qt::CaseInsensitive) + 6);
         bool mismatch = false;
         int l = expectedVersion.length();
         if (l == 1 && expectedVersion[0] != mPythonShortVersion[0])
           mismatch = true;
-        if (l >= 3 &&
-            (expectedVersion[0] != mPythonShortVersion[0] || expectedVersion[2] != mPythonShortVersion[1]))
+        if (l >= 3 && (expectedVersion[0] != mPythonShortVersion[0] || expectedVersion[2] != mPythonShortVersion[1]))
           mismatch = true;
         if (mismatch)
-          warn(tr("Python shebang requests python%1, but current path points to Python%2").arg(expectedVersion, mPythonShortVersion));
+          warn(tr("Python shebang requests python%1, but current path points to Python%2")
+                 .arg(expectedVersion, mPythonShortVersion));
 #endif
       }
       pythonSourceFile.close();

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -486,7 +486,6 @@ void WbController::setProcessEnvironment() {
       mPythonCommand = WbLanguageTools::pythonCommand(
         mPythonShortVersion, WbPreferences::instance()->value("General/pythonCommand", "python").toString());
     // read the python shebang (first line starting with #!) to possibly override the python command
-    QString expectedVersion;
     QFile pythonSourceFile(mControllerPath + name() + ".py");
     if (pythonSourceFile.open(QIODevice::ReadOnly)) {
       QTextStream in(&pythonSourceFile);
@@ -498,7 +497,7 @@ void WbController::setProcessEnvironment() {
         else
           mPythonCommand = WbLanguageTools::pythonCommand(mPythonShortVersion, line.mid(2).trimmed());
 #else  // Windows: check that the version specified in the shebang corresponds to the version of Python installed
-        expectedVersion = line.mid(line.lastIndexOf("python", -1, Qt::CaseInsensitive) + 6);
+        const QString expectedVersion = line.mid(line.lastIndexOf("python", -1, Qt::CaseInsensitive) + 6);
         bool mismatch = false;
         int l = expectedVersion.length();
         if (l == 1 && expectedVersion[0] != mPythonShortVersion[0])


### PR DESCRIPTION
The python shebang of controller programs was totally ignored by Webots causing some misleading behaviors: although the shebang was indicating to run python 3, Webots may silently run Python 2.7. This PR fixes this problem by reading the standard shebang of controller programs to determine which version of python to use. On Windows, shebangs are not supported, so a warning is displayed in case of version mismatch.