### PR TITLE
webots.min.js: fix toolbar run button status and context menu

### DIFF
--- a/resources/web/wwi/toolbar.js
+++ b/resources/web/wwi/toolbar.js
@@ -299,12 +299,22 @@ class Toolbar { // eslint-disable-line no-unused-vars
   }
 
   setMode(mode) {
-    if (mode === 'pause')
+    var fastEnabled = typeof this.fastButton !== 'undefined';
+    if (mode === 'pause') {
       this.pauseButton.style.display = 'none';
-    else
-      this.pauseButton.style.display = 'inline';
-    this.real_timeButton.style.display = 'inline';
-    if (typeof this.fastButton !== 'undefined')
+      this.real_timeButton.style.display = 'inline';
+      if (fastEnabled)
+        this.fastButton.style.display = 'inline';
+      return;
+    }
+
+    this.pauseButton.style.display = 'inline';
+    if (fastEnabled && mode === 'fast') {
+      this.fastButton.style.display = 'none';
+      this.real_timeButton.style.display = 'inline';
+    } else {
       this.fastButton.style.display = 'inline';
+      this.real_timeButton.style.display = 'none';
+    }
   }
 }

--- a/resources/web/wwi/toolbar.js
+++ b/resources/web/wwi/toolbar.js
@@ -38,8 +38,10 @@ class Toolbar { // eslint-disable-line no-unused-vars
     this.pauseButton.onclick = () => { this.pause(); };
     this.pauseButton.style.display = 'none';
 
-    this.domElement.left.appendChild(this.createToolBarButton('fast', 'Run the simulation as fast as possible'));
-    this.fastButton.onclick = () => { this.fast(); };
+    if (webots.showFast) { // disabled by default
+      this.domElement.left.appendChild(this.createToolBarButton('fast', 'Run the simulation as fast as possible'));
+      this.fastButton.onclick = () => { this.fast(); };
+    }
 
     var div = document.createElement('div');
     div.className = 'webotsTime';

--- a/resources/web/wwi/webots.js
+++ b/resources/web/wwi/webots.js
@@ -35,7 +35,7 @@ webots.User2Name           // user name of the secondary user.
 webots.CustomData          // application specific data to be passed to the simulation server
 webots.showRevert          // defines whether the revert button should be displayed
 webots.showQuit            // defines whether the quit button should be displayed
-
+webots.showFast            // defines whether the fast button should be displayed
 */
 
 webots.View = class View {

--- a/resources/web/wwi/webots.js
+++ b/resources/web/wwi/webots.js
@@ -332,7 +332,10 @@ webots.View = class View {
     }
 
     if (typeof this.contextMenu === 'undefined' && this.isWebSocketProtocol) {
-      this.contextMenu = new ContextMenu((typeof webots.User1Id !== 'undefined' || webots.User1Id !== '') && webots.User1Authentication, this.view3D);
+      let authenticatedUser = !this.broadcast;
+      if (authenticatedUser && typeof webots.User1Id !== 'undefined' && webots.User1Id !== '')
+        authenticatedUser = Boolean(webots.User1Authentication);
+      this.contextMenu = new ContextMenu(authenticatedUser, this.view3D);
       this.contextMenu.onEditController = (controller) => { this.editController(controller); };
       this.contextMenu.onFollowObject = (id) => { this.x3dScene.viewpoint.follow(id); };
       this.contextMenu.isFollowedObject = (object3d, setResult) => { setResult(this.x3dScene.viewpoint.isFollowedObject(object3d)); };

--- a/src/webots/gui/WbStreamingServer.hpp
+++ b/src/webots/gui/WbStreamingServer.hpp
@@ -84,6 +84,8 @@ private:
   void propagateLogToClients(WbLog::Level level, const QString &message);
   bool isControllerMessageIgnored(const QString &pattern, const QString &message) const;
 
+  static QString simulationStateString();
+
   QString mX3dWorld;
   QHash<QString, QString> mX3dWorldTextures;
   double mX3dWorldGenerationTime;


### PR DESCRIPTION
Complete fix #795 not working  and enabling/disabling of run mode buttons in the toolbar in broadcast mode.

* [x] hide fast button by default (and in robotbenchmark)

Streaming viewer issues:
* [x] when running the simulation the pause button is added in between the real_time and fast buttons instead of replacing one of them
* [x] when connecting to an already running simulation, the run (real_time or fast) icon is displayed instead of the pause icon 