### PR TITLE
Fix Python37 not released on Linux

### DIFF
--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -26,6 +26,7 @@ Released on XXX YYth, 2019.
     - Fixed external controllers, now when a controller exits, the simulation keeps running and it is possible to re-start another external controller.
     - Webots now reads the Python shebang of controller programs to determine which version of Python to execute.
     - External controllers now wait if started before Webots.
+    - Linux: Fixed missing Python3.7 controller API. 
 
 ## [Webots R2019b](../blog/Webots-2019-b-release.md)
 Released on June 25th, 2019.

--- a/src/packaging/files_core.txt
+++ b/src/packaging/files_core.txt
@@ -193,10 +193,10 @@ lib/python36/ [linux]
 lib/python36/*.py [linux]
 lib/python36/_*.so [linux]
 
-lib/python37/ [windows,mac]
-lib/python37/*.py [windows,mac]
+lib/python37/
+lib/python37/*.py
+lib/python37/_*.so [linux,mac]
 lib/python37/_*.pyd [windows]
-lib/python37/_*.so [mac]
 
 lib/matlab/
 lib/matlab/allincludes.h


### PR DESCRIPTION
We document that Python37 is available on Linux (https://www.cyberbotics.com/doc/guide/using-python#introduction), but that was not actually the case.