### PR TITLE
Fix possible dll conflict on windows

### DIFF
--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -26,7 +26,8 @@ Released on XXX YYth, 2019.
     - Fixed external controllers, now when a controller exits, the simulation keeps running and it is possible to re-start another external controller.
     - Webots now reads the Python shebang of controller programs to determine which version of Python to execute.
     - External controllers now wait if started before Webots.
-    - Linux: Fixed missing Python3.7 controller API. 
+    - Linux: Fixed missing Python3.7 controller API.
+    - Windows: Fixed possible DLL conflict with libssl-1_1-x64.dll and libcrypto-1_1-x64.dll.
 
 ## [Webots R2019b](../blog/Webots-2019-b-release.md)
 Released on June 25th, 2019.

--- a/src/packaging/files_msys64.txt
+++ b/src/packaging/files_msys64.txt
@@ -44,6 +44,8 @@
 /mingw64/bin/libzzip-0-13.dll
 /mingw64/bin/libopenal-1.dll
 /mingw64/bin/libassimp.dll
+/mingw64/bin/libssl-1_1-x64.dll
+/mingw64/bin/libcrypto-1_1-x64.dll
 /mingw64/share/qt5/plugins/imageformats/qjpeg.dll
 /mingw64/share/qt5/plugins/platforms/qwindows.dll
 /mingw64/share/qt5/plugins/printsupport/windowsprintersupport.dll


### PR DESCRIPTION
Following a user bug report (support ticket 2649), this fix guarantees that we use the correct version of libssl on Windows.