### PR TITLE
webots.min.js: fix 'this' object in static methods

### DIFF
--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -21,6 +21,7 @@ Released on XXX YYth, 2019.
       - Fixed [Fog](fog.md) type.
       - Fixed [ElevationGrid](elevationgrid.md) normals.
       - Fixed [Background](background.md) default color.
+      - Fixed bugs on `webots.alert` and `webots.confirm` messages.
     - Fixed `realistic_village.wbt` materials.
     - Fixed the insertion of a PROTO containing a [BallJoint](balljoint.md).
     - Fixed ros controller not publishing the `/connector/presence` topic.

--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -21,7 +21,7 @@ Released on XXX YYth, 2019.
       - Fixed [Fog](fog.md) type.
       - Fixed [ElevationGrid](elevationgrid.md) normals.
       - Fixed [Background](background.md) default color.
-      - Fixed bugs on `webots.alert` and `webots.confirm` messages.
+      - Fixed bugs on `webots.alert`, `webots.confirm`, and editor reset dialogs.
     - Fixed `realistic_village.wbt` materials.
     - Fixed the insertion of a PROTO containing a [BallJoint](balljoint.md).
     - Fixed ros controller not publishing the `/connector/presence` topic.

--- a/resources/web/wwi/console.js
+++ b/resources/web/wwi/console.js
@@ -8,7 +8,7 @@ class Console extends DialogWindow { // eslint-disable-line no-unused-vars
     this.panel.id = 'webotsConsole';
     this.panel.className = 'webotsConsole';
 
-    var clampedSize = super.clampDialogSize({left: 0, top: 0, width: 600, height: 400});
+    var clampedSize = DialogWindow.clampDialogSize({left: 0, top: 0, width: 600, height: 400});
     this.params.width = clampedSize.width;
     this.params.height = clampedSize.height;
     this.params.close = () => { $('#consoleButton').removeClass('toolBarButtonActive'); };

--- a/resources/web/wwi/dialog_window.js
+++ b/resources/web/wwi/dialog_window.js
@@ -10,18 +10,18 @@ class DialogWindow { // eslint-disable-line no-unused-vars
 
     this.params = {
       appendTo: parent,
-      open: () => { this.openDialog(this.panel); },
+      open: () => { DialogWindow.openDialog(this.panel); },
       autoOpen: false,
-      resizeStart: this.disablePointerEvents,
-      resizeStop: this.enablePointerEvents,
-      dragStart: this.disablePointerEvents,
-      dragStop: this.enablePointerEvents
+      resizeStart: DialogWindow.disablePointerEvents,
+      resizeStop: DialogWindow.enablePointerEvents,
+      dragStart: DialogWindow.disablePointerEvents,
+      dragStop: DialogWindow.enablePointerEvents
     };
     if (this.mobile)
-      this.addMobileDialogAttributes(this.params, this.panel);
+      DialogWindow.addMobileDialogAttributes(this.params, this.panel);
   }
 
-  clampDialogSize(preferredGeometry) {
+  static clampDialogSize(preferredGeometry) {
     if (typeof $('#playerDiv').height === 'undefined' || typeof $('#playerDiv').width === 'undefined')
       return preferredGeometry;
 
@@ -36,8 +36,8 @@ class DialogWindow { // eslint-disable-line no-unused-vars
     return {width: width, height: height};
   }
 
-  openDialog(dialog) {
-    this.resizeDialogOnOpen(dialog);
+  static openDialog(dialog) {
+    DialogWindow.resizeDialogOnOpen(dialog);
     $(dialog).parent().css('opacity', 0.9);
     $(dialog).parent().hover(() => {
       $(dialog).css('opacity', 0.99);
@@ -46,17 +46,17 @@ class DialogWindow { // eslint-disable-line no-unused-vars
     });
   }
 
-  resizeDialogOnOpen(dialog) {
+  static resizeDialogOnOpen(dialog) {
     var w = $(dialog).parent().width();
     var h = $(dialog).parent().height();
-    var clampedSize = this.clampDialogSize({left: 0, top: 0, width: w, height: h});
+    var clampedSize = DialogWindow.clampDialogSize({left: 0, top: 0, width: w, height: h});
     if (clampedSize.width < w)
       $(dialog).dialog('option', 'width', clampedSize.width);
     if (clampedSize.height < h)
       $(dialog).dialog('option', 'height', clampedSize.height);
   }
 
-  mobileCreateDialog() {
+  static mobileCreateDialog() {
     // mobile only setup
     var closeButton = $('button:contains("WbClose")');
     closeButton.html('');
@@ -66,19 +66,19 @@ class DialogWindow { // eslint-disable-line no-unused-vars
     closeButton.prepend('<span class="ui-icon ui-icon-closethick"></span>');
   }
 
-  addMobileDialogAttributes(params, panel) {
+  static addMobileDialogAttributes(params, panel) {
     params.dialogClass = 'mobile-no-default-buttons';
-    params.create = () => { this.mobileCreateDialog(); };
+    params.create = () => { DialogWindow.mobileCreateDialog(); };
     params.buttons = { 'WbClose': () => { $(panel).dialog('close'); } };
   }
 
   // The following two functions are used to make the resize and drag of the dialog
   // steady (i.e., not loose the grab while resizing/dragging the dialog quickly).
-  disablePointerEvents() {
+  static disablePointerEvents() {
     document.body.style['pointer-events'] = 'none';
   }
 
-  enablePointerEvents() {
+  static enablePointerEvents() {
     document.body.style['pointer-events'] = 'auto';
   }
 }
@@ -95,12 +95,12 @@ webots.alert = (title, message, callback) => {
   panel.innerHTML = message;
   $('#webotsAlert').dialog({
     title: title,
-    resizeStart: this.disablePointerEvents,
-    resizeStop: this.enablePointerEvents,
-    dragStart: this.disablePointerEvents,
-    dragStop: this.enablePointerEvents,
+    resizeStart: DialogWindow.disablePointerEvents,
+    resizeStop: DialogWindow.enablePointerEvents,
+    dragStart: DialogWindow.disablePointerEvents,
+    dragStop: DialogWindow.enablePointerEvents,
     appendTo: parent,
-    open: this.openDialog,
+    open: () => { DialogWindow.openDialog(panel); },
     modal: true,
     width: 400, // enough room to display the social network buttons in a line
     buttons: {
@@ -124,12 +124,12 @@ webots.confirm = (title, message, callback) => {
   parent.appendChild(panel);
   $('#webotsConfirm').dialog({
     title: title,
-    resizeStart: this.disablePointerEvents,
-    resizeStop: this.enablePointerEvents,
-    dragStart: this.disablePointerEvents,
-    dragStop: this.enablePointerEvents,
+    resizeStart: DialogWindow.disablePointerEvents,
+    resizeStop: DialogWindow.enablePointerEvents,
+    dragStart: DialogWindow.disablePointerEvents,
+    dragStop: DialogWindow.enablePointerEvents,
     appendTo: parent,
-    open: this.openDialog,
+    open: () => { DialogWindow.openDialog(panel); },
     modal: true,
     width: 400, // enough room to display the social network buttons in a line
     buttons: {

--- a/resources/web/wwi/dialog_window.js
+++ b/resources/web/wwi/dialog_window.js
@@ -56,7 +56,7 @@ class DialogWindow { // eslint-disable-line no-unused-vars
       $(dialog).dialog('option', 'height', clampedSize.height);
   }
 
-  static mobileCreateDialog() {
+  static createMobileDialog() {
     // mobile only setup
     var closeButton = $('button:contains("WbClose")');
     closeButton.html('');
@@ -68,7 +68,7 @@ class DialogWindow { // eslint-disable-line no-unused-vars
 
   static addMobileDialogAttributes(params, panel) {
     params.dialogClass = 'mobile-no-default-buttons';
-    params.create = () => { DialogWindow.mobileCreateDialog(); };
+    params.create = DialogWindow.createMobileDialog;
     params.buttons = { 'WbClose': () => { $(panel).dialog('close'); } };
   }
 

--- a/resources/web/wwi/editor.js
+++ b/resources/web/wwi/editor.js
@@ -50,12 +50,12 @@ class Editor extends DialogWindow { // eslint-disable-line no-unused-vars
                           '</div>';
     this.panel.appendChild(this.menu);
 
-    var clampedSize = super.clampDialogSize({left: 0, top: 0, width: 800, height: 600});
+    var clampedSize = DialogWindow.clampDialogSize({left: 0, top: 0, width: 800, height: 600});
     this.params.width = clampedSize.width;
     this.params.height = clampedSize.height;
     this.params.close = null;
     this.params.resize = () => { this._resize(); };
-    this.params.open = () => { this.resizeDialogOnOpen(this.panel); };
+    this.params.open = () => { DialogWindow.resizeDialogOnOpen(this.panel); };
     this.params.title = 'Editor';
 
     $(this.panel).dialog(this.params).dialogExtend({maximizable: !mobile});
@@ -217,7 +217,7 @@ class Editor extends DialogWindow { // eslint-disable-line no-unused-vars
       autoOpen: true,
       resizable: false,
       dialogClass: 'alert',
-      open: () => { this.openDialog(this); },
+      open: () => { DialogWindow.openDialog(confirmDialog); },
       appendTo: this.parent,
       buttons: {
         'Cancel': () => {

--- a/resources/web/wwi/editor.js
+++ b/resources/web/wwi/editor.js
@@ -221,11 +221,11 @@ class Editor extends DialogWindow { // eslint-disable-line no-unused-vars
       appendTo: this.parent,
       buttons: {
         'Cancel': () => {
-          $(this).dialog('close');
+          $(confirmDialog).dialog('close');
           $('#webotsEditorConfirmDialog').remove();
         },
         'Reset': () => {
-          $(this).dialog('close');
+          $(confirmDialog).dialog('close');
           $('#webotsEditorConfirmDialog').remove();
           if (this.resetAllFiles) {
             this.filenames.forEach((filename) => {

--- a/resources/web/wwi/help_window.js
+++ b/resources/web/wwi/help_window.js
@@ -26,7 +26,7 @@ class HelpWindow extends DialogWindow { // eslint-disable-line no-unused-vars
       $('#webotsHelpTabs').tabs();
     }
 
-    var clampedSize = super.clampDialogSize({left: 5, top: 5, width: 600, height: 600});
+    var clampedSize = DialogWindow.clampDialogSize({left: 5, top: 5, width: 600, height: 600});
     this.params.width = clampedSize.width;
     this.params.height = clampedSize.height;
     this.params.close = () => { $('#helpButton').removeClass('toolBarButtonActive'); };

--- a/resources/web/wwi/robot_window.js
+++ b/resources/web/wwi/robot_window.js
@@ -8,7 +8,7 @@ class RobotWindow extends DialogWindow { // eslint-disable-line no-unused-vars
     this.panel.id = name;
     this.panel.className = 'webotsTabContainer';
 
-    var clampedSize = super.clampDialogSize({left: 5, top: 5, width: 400, height: 400});
+    var clampedSize = DialogWindow.clampDialogSize({left: 5, top: 5, width: 400, height: 400});
     this.params.width = clampedSize.width;
     this.params.height = clampedSize.height;
     this.params.close = null;

--- a/resources/web/wwi/toolbar.js
+++ b/resources/web/wwi/toolbar.js
@@ -185,7 +185,7 @@ class Toolbar { // eslint-disable-line no-unused-vars
           modal: true,
           resizable: false,
           appendTo: this.view.view3D,
-          open: DialogWindow.openDialog,
+          open: () => { DialogWindow.openDialog(quitDialog); },
           buttons: {
             'Cancel': () => {
               $(quitDialog).dialog('close');
@@ -315,7 +315,8 @@ class Toolbar { // eslint-disable-line no-unused-vars
       this.fastButton.style.display = 'none';
       this.real_timeButton.style.display = 'inline';
     } else {
-      this.fastButton.style.display = 'inline';
+      if (fastEnabled)
+        this.fastButton.style.display = 'inline';
       this.real_timeButton.style.display = 'none';
     }
   }


### PR DESCRIPTION
Remove calls  to `this` object in static methods of `dialog_window.js`.
This was causing issues when calling `webots.alert` and `webots.confirm` functions.