### PR TITLE
webots.min.js/macOS: Fix `Ctrl + left click`

### DIFF
--- a/resources/web/wwi/Makefile
+++ b/resources/web/wwi/Makefile
@@ -21,6 +21,7 @@ JS_SOURCES = \
   equirectangular_to_cube_generator.js \
   gpu_picker.js \
   util.js \
+  system_info.js \
   dialog_window.js \
   console.js \
   help_window.js \

--- a/resources/web/wwi/mouse_events.js
+++ b/resources/web/wwi/mouse_events.js
@@ -46,6 +46,9 @@ class MouseEvents { // eslint-disable-line no-unused-vars
         this.state.mouseDown |= 2;
         break;
     }
+    if (SystemInfo.isMacOS() && 'ctrlKey' in event && event['ctrlKey'] && this.state.mouseDown === 1)
+      // On macOS, "Ctrl + click" should be dealt as a right click.
+      this.state.mouseDown = 2;
 
     if (this.state.mouseDown !== 0) {
       this._setupMoveParameters(event, true);

--- a/resources/web/wwi/mouse_events.js
+++ b/resources/web/wwi/mouse_events.js
@@ -1,4 +1,4 @@
-/* global webots, THREE */
+/* global webots, THREE, SystemInfo */
 'use strict';
 
 class MouseEvents { // eslint-disable-line no-unused-vars
@@ -81,6 +81,10 @@ class MouseEvents { // eslint-disable-line no-unused-vars
         default: this.state.pressedButton = 0; break;
       }
     }
+    if (SystemInfo.isMacOS() && 'ctrlKey' in event && event['ctrlKey'] && this.state.mouseDown === 1)
+      // On macOS, "Ctrl + click" should be managed as a right click.
+      this.state.mouseDown = 2;
+
     if (this.state.mouseDown === 0)
       return;
 

--- a/resources/web/wwi/mouse_events.js
+++ b/resources/web/wwi/mouse_events.js
@@ -47,7 +47,7 @@ class MouseEvents { // eslint-disable-line no-unused-vars
         break;
     }
     if (SystemInfo.isMacOS() && 'ctrlKey' in event && event['ctrlKey'] && this.state.mouseDown === 1)
-      // On macOS, "Ctrl + click" should be dealt as a right click.
+      // On macOS, "Ctrl + left click" should be dealt as a right click.
       this.state.mouseDown = 2;
 
     if (this.state.mouseDown !== 0) {
@@ -85,7 +85,7 @@ class MouseEvents { // eslint-disable-line no-unused-vars
       }
     }
     if (SystemInfo.isMacOS() && 'ctrlKey' in event && event['ctrlKey'] && this.state.mouseDown === 1)
-      // On macOS, "Ctrl + click" should be dealt as a right click.
+      // On macOS, "Ctrl + left click" should be dealt as a right click.
       this.state.mouseDown = 2;
 
     if (this.state.mouseDown === 0)

--- a/resources/web/wwi/mouse_events.js
+++ b/resources/web/wwi/mouse_events.js
@@ -82,7 +82,7 @@ class MouseEvents { // eslint-disable-line no-unused-vars
       }
     }
     if (SystemInfo.isMacOS() && 'ctrlKey' in event && event['ctrlKey'] && this.state.mouseDown === 1)
-      // On macOS, "Ctrl + click" should be managed as a right click.
+      // On macOS, "Ctrl + click" should be dealt as a right click.
       this.state.mouseDown = 2;
 
     if (this.state.mouseDown === 0)

--- a/resources/web/wwi/system_info.js
+++ b/resources/web/wwi/system_info.js
@@ -1,0 +1,7 @@
+/* exported SystemInfo */
+
+class SystemInfo {
+  static isMacOS() {
+    return navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+  }
+}


### PR DESCRIPTION
Fix https://github.com/omichel/robotbenchmark/issues/303

- [x] On macOS, deal with "Ctrl + left click" as a right click