### PR TITLE
webots.min.js: Fix context menu on Firefox/Windows 10

### DIFF
--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -22,6 +22,7 @@ Released on XXX YYth, 2019.
       - Fixed [ElevationGrid](elevationgrid.md) normals.
       - Fixed [Background](background.md) default color.
       - Fixed bugs on `webots.alert`, `webots.confirm`, and editor reset dialogs.
+      - Fixed context menu on Firefox / Windows 10.
     - Fixed `realistic_village.wbt` materials.
     - Fixed the insertion of a PROTO containing a [BallJoint](balljoint.md).
     - Fixed ros controller not publishing the `/connector/presence` topic.

--- a/resources/web/wwi/mouse_events.js
+++ b/resources/web/wwi/mouse_events.js
@@ -29,6 +29,10 @@ class MouseEvents { // eslint-disable-line no-unused-vars
     domElement.addEventListener('wheel', (event) => { this._onMouseWheel(event); }, false);
     domElement.addEventListener('touchstart', (event) => { this._onTouchStart(event); }, true);
     domElement.addEventListener('contextmenu', (event) => { event.preventDefault(); }, false);
+
+    // Prevent '#playerDiv' to raise the context menu of the browser.
+    // This bug has been seen on Windows 10 / Firefox only.
+    domElement.parentNode.addEventListener('contextmenu', (event) => { event.preventDefault(); }, false);
   }
 
   _onMouseDown(event) {


### PR DESCRIPTION
Fix https://github.com/omichel/robotbenchmark/issues/344

I only see this issue on Firefox + Windows 10 (Edge or other Firefox versions are working fine with this). 

'#playerDiv' (the canvas parent) raises the context menu of the browser; this event should be simply prevented. It's probably safer to apply this patch systematically on every browser.

| Bug | Fix |
| --- | --- |
| ![bug](https://user-images.githubusercontent.com/866788/63363056-30ddac00-c373-11e9-9a0a-1c052d580d66.png) | ![fix](https://user-images.githubusercontent.com/866788/63363058-30ddac00-c373-11e9-9368-b2f4f90a83da.png) |