### PR TITLE
Fix race stop watch

### DIFF
--- a/projects/samples/robotbenchmark/humanoid_sprint/controllers/race_stopwatch/race_stopwatch.c
+++ b/projects/samples/robotbenchmark/humanoid_sprint/controllers/race_stopwatch/race_stopwatch.c
@@ -84,16 +84,17 @@ int main(int argc, char *argv[]) {
   WbFieldRef translation = wb_supervisor_node_get_field(nao, "translation");
   int run = 1;
   double record = 0;
-  double penalty = 0;
-  bool has_penalty = false;
+  bool disqualified = false;
+  const double time_limit = 5999.99 - time_step / 1000.0;  // 99 min 59 s 99' - discrepancy time
   do {
+    double t = wb_robot_get_time();
     const double *v = wb_supervisor_field_get_sf_vec3f(translation);
-    if (!has_penalty && v[1] < 0.2) {  // the robot has fallen down
-      printf("The robot is down, a penalty of 30 seconds is added.\n");
-      penalty += 30;
-      has_penalty = true;
+    if (!disqualified && v[1] < 0.2) {  // the robot has fallen down
+      printf("The robot is down, the robot is disqualified.\n");
+      disqualified = true;
     }
-    double t = wb_robot_get_time() + penalty;
+    if (disqualified || t > time_limit)
+      t = time_limit;
     if (run) {
       stopwatch_set_time(digit, t + time_step / 1000);  // to avoid discrepancy with Webots time
       char buffer[32];

--- a/projects/samples/robotbenchmark/humanoid_sprint/controllers/race_stopwatch/race_stopwatch.c
+++ b/projects/samples/robotbenchmark/humanoid_sprint/controllers/race_stopwatch/race_stopwatch.c
@@ -85,13 +85,13 @@ int main(int argc, char *argv[]) {
   int run = 1;
   double record = 0;
   double penalty = 0;
-  bool has_penality = false;
+  bool has_penalty = false;
   do {
     const double *v = wb_supervisor_field_get_sf_vec3f(translation);
-    if (!has_penality && v[1] < 0.2) {  // the robot has fallen down
+    if (!has_penalty && v[1] < 0.2) {  // the robot has fallen down
       printf("The robot is down, a penalty of 30 seconds is added.\n");
       penalty += 30;
-      has_penality = true;
+      has_penalty = true;
     }
     double t = wb_robot_get_time() + penalty;
     if (run) {

--- a/projects/samples/robotbenchmark/humanoid_sprint/controllers/race_stopwatch/race_stopwatch.c
+++ b/projects/samples/robotbenchmark/humanoid_sprint/controllers/race_stopwatch/race_stopwatch.c
@@ -85,11 +85,13 @@ int main(int argc, char *argv[]) {
   int run = 1;
   double record = 0;
   double penalty = 0;
+  bool has_penality = false;
   do {
     const double *v = wb_supervisor_field_get_sf_vec3f(translation);
-    if (v[1] < 0.2) {  // the robot has fallen down
+    if (!has_penality && v[1] < 0.2) {  // the robot has fallen down
       printf("The robot is down, a penalty of 30 seconds is added.\n");
       penalty += 30;
+      has_penality = true;
     }
     double t = wb_robot_get_time() + penalty;
     if (run) {


### PR DESCRIPTION
Fix https://github.com/omichel/robotbenchmark/issues/327

When a the robot falls, the 30s time penalty is added every milliseconds. Soon enough, the timer (supporting 100 minutes) is overloaded causing weird results.

Adding a disqualifying penalty fix this issue.
