### PR TITLE
Fixed the installation of npm on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,20 +83,21 @@ jobs:
             - libfreetype6-dev
             - libxml2-dev
             - libzzip-0-13
-            - libssl-dev
+            - libssl1.0-dev
             - libboost-dev
             - libjpeg8-dev
             - libavcodec-extra
             - libpci-dev
             - libgd-dev
             - libtiff5-dev
-            - libssh-dev
+            - libssh-gcrypt-dev
             - libzip-dev
             - python-pip
             - libreadline-dev
             - libassimp-dev
             - libpng12-dev
             - libav-tools
+            - npm
             - python3.5-dev
             - openjdk-8-jdk
             - curl
@@ -136,8 +137,6 @@ jobs:
         - sudo add-apt-repository ppa:deadsnakes/ppa -y
         - sudo apt update
         - sudo apt install python3.6-dev python3.7-dev
-        - curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
-        - sudo apt install nodejs
         - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
         - export PATH=$JAVA_HOME/bin:$PATH
         - pip install PyGithub # used to upload packages to Github releases

--- a/src/packaging/Makefile
+++ b/src/packaging/Makefile
@@ -40,11 +40,16 @@ LIBRARIES = -lcrypto
 WEBOTS_DISTRO_EXE = webots_distro
 WEBOTS = $(WEBOTS_HOME_PATH)/webots
 ifeq ($(UBUNTU_VERSION),16.04)
-CFLAGS=-DWEBOTS_UBUNTU_16_04
+CFLAGS = -DWEBOTS_UBUNTU_16_04
 endif
 ifeq ($(UBUNTU_VERSION),18.04)
-CFLAGS=-DWEBOTS_UBUNTU_18_04
+CFLAGS = -DWEBOTS_UBUNTU_18_04
 endif
+endif
+
+ifneq ($(SNAPCRAFT_PROJECT_NAME),)
+export DISPLAY = :99
+XVFB = xvfb
 endif
 
 ifeq ($(OSTYPE),windows)
@@ -55,7 +60,7 @@ WEBOTS = webots
 ISCC_FORMATTER = iscc_formatter.exe
 endif
 
-all: $(WEBOTS_DISTRO_EXE) $(ISCC_FORMATTER)
+all: $(WEBOTS_DISTRO_EXE) $(ISCC_FORMATTER) $(XVFB)
 	+@echo "# removing files and folders not in git repository"
 	+@cd $(WEBOTS_HOME_PATH) ; git clean -fdf | sed -e 's/^/# - /' ; cd src/packaging
 	+@echo "# generating project files"
@@ -83,12 +88,16 @@ endif
 	+@echo "# done for" $(OSTYPE)
 
 $(WEBOTS_DISTRO_EXE): webots_distro.c
-	+@ echo "# compiling webots_distro.c"
+	+@echo "# compiling webots_distro.c"
 	+@$(CC) $(CFLAGS) -Wall -o $@ webots_distro.c $(LIBRARIES)
 
 iscc_formatter.exe: iscc_formatter.c
-	+@ echo "# compiling iscc_formatter.c"
+	+@echo "# compiling iscc_formatter.c"
 	+@$(CC) -Wall -o $@ iscc_formatter.c
+
+xvfb:
+	+@echo "# starting Xvfb: X Virtual Frame Buffer"
+	+@Xvfb :99 -screen 0 1024x768x16 &
 
 clean:
 	+@rm -rf $(WEBOTS_DISTRO_EXE) webots*.deb webots.iss msys64_f*s.iss webots-for-*.iss webots*.mac files.txt iscc_formatter.exe

--- a/src/packaging/Makefile
+++ b/src/packaging/Makefile
@@ -40,16 +40,11 @@ LIBRARIES = -lcrypto
 WEBOTS_DISTRO_EXE = webots_distro
 WEBOTS = $(WEBOTS_HOME_PATH)/webots
 ifeq ($(UBUNTU_VERSION),16.04)
-CFLAGS = -DWEBOTS_UBUNTU_16_04
+CFLAGS=-DWEBOTS_UBUNTU_16_04
 endif
 ifeq ($(UBUNTU_VERSION),18.04)
-CFLAGS = -DWEBOTS_UBUNTU_18_04
+CFLAGS=-DWEBOTS_UBUNTU_18_04
 endif
-endif
-
-ifneq ($(SNAPCRAFT_PROJECT_NAME),)
-export DISPLAY = :99
-XVFB = xvfb
 endif
 
 ifeq ($(OSTYPE),windows)
@@ -60,7 +55,7 @@ WEBOTS = webots
 ISCC_FORMATTER = iscc_formatter.exe
 endif
 
-all: $(WEBOTS_DISTRO_EXE) $(ISCC_FORMATTER) $(XVFB)
+all: $(WEBOTS_DISTRO_EXE) $(ISCC_FORMATTER)
 	+@echo "# removing files and folders not in git repository"
 	+@cd $(WEBOTS_HOME_PATH) ; git clean -fdf | sed -e 's/^/# - /' ; cd src/packaging
 	+@echo "# generating project files"
@@ -88,16 +83,12 @@ endif
 	+@echo "# done for" $(OSTYPE)
 
 $(WEBOTS_DISTRO_EXE): webots_distro.c
-	+@echo "# compiling webots_distro.c"
+	+@ echo "# compiling webots_distro.c"
 	+@$(CC) $(CFLAGS) -Wall -o $@ webots_distro.c $(LIBRARIES)
 
 iscc_formatter.exe: iscc_formatter.c
-	+@echo "# compiling iscc_formatter.c"
+	+@ echo "# compiling iscc_formatter.c"
 	+@$(CC) -Wall -o $@ iscc_formatter.c
-
-xvfb:
-	+@echo "# starting Xvfb: X Virtual Frame Buffer"
-	+@Xvfb :99 -screen 0 1024x768x16 &
 
 clean:
 	+@rm -rf $(WEBOTS_DISTRO_EXE) webots*.deb webots.iss msys64_f*s.iss webots-for-*.iss webots*.mac files.txt iscc_formatter.exe


### PR DESCRIPTION
This PR makes that travis install will the `npm` package the same was we do it manually following the new explanations here: https://github.com/omichel/webots/wiki/Linux-installation.

It is simpler and greatly facilitates the build on snapcraft.io.