### PR TITLE
Fix path to python versions of robotis managers

### DIFF
--- a/projects/samples/robotbenchmark/humanoid_marathon/controllers/marathon/runtime.ini
+++ b/projects/samples/robotbenchmark/humanoid_marathon/controllers/marathon/runtime.ini
@@ -1,5 +1,5 @@
 [environment variables with relative paths]
 
 ROBOTIS_PATH=$(WEBOTS_HOME)/projects/robots/robotis/darwin-op
-WEBOTS_LIBRARY_PATH=$(ROBOTIS_PATH)/libraries/python27:$(ROBOTIS_PATH)/libraries/python35:$(ROBOTIS_PATH)/libraries/python36:$(ROBOTIS_PATH)/libraries/python37:$(ROBOTIS_PATH)/libraries/robotis-op2:$(ROBOTIS_PATH)/libraries/managers:$(WEBOTS_LIBRARY_PATH)
+WEBOTS_LIBRARY_PATH=$(ROBOTIS_PATH)/libraries/python:$(ROBOTIS_PATH)/libraries/python27:$(ROBOTIS_PATH)/libraries/python35:$(ROBOTIS_PATH)/libraries/python36:$(ROBOTIS_PATH)/libraries/python37:$(ROBOTIS_PATH)/libraries/robotis-op2:$(ROBOTIS_PATH)/libraries/managers:$(WEBOTS_LIBRARY_PATH)
 FIREJAIL_PATH=$(ROBOTIS_PATH)/plugins/remote_controls/robotis-op2_tcpip/librobotis-op2_tcpip.so

--- a/projects/samples/robotbenchmark/humanoid_marathon/controllers/marathon/runtime.ini
+++ b/projects/samples/robotbenchmark/humanoid_marathon/controllers/marathon/runtime.ini
@@ -1,5 +1,5 @@
 [environment variables with relative paths]
 
 ROBOTIS_PATH=$(WEBOTS_HOME)/projects/robots/robotis/darwin-op
-WEBOTS_LIBRARY_PATH=$(ROBOTIS_PATH)/libraries/python:$(ROBOTIS_PATH)/libraries/robotis-op2:$(ROBOTIS_PATH)/libraries/managers:$(WEBOTS_LIBRARY_PATH)
+WEBOTS_LIBRARY_PATH=$(ROBOTIS_PATH)/libraries/python27:$(ROBOTIS_PATH)/libraries/python35:$(ROBOTIS_PATH)/libraries/python36:$(ROBOTIS_PATH)/libraries/python37:$(ROBOTIS_PATH)/libraries/robotis-op2:$(ROBOTIS_PATH)/libraries/managers:$(WEBOTS_LIBRARY_PATH)
 FIREJAIL_PATH=$(ROBOTIS_PATH)/plugins/remote_controls/robotis-op2_tcpip/librobotis-op2_tcpip.so


### PR DESCRIPTION
Fix issue https://github.com/omichel/robotbenchmark/issues/349: to support multiple versions of python we now also have to link to the specific python folder other than the generic 'python' folder kept for backward compatibility.